### PR TITLE
Fix application_credential targets in notifications

### DIFF
--- a/keystone/notifications.py
+++ b/keystone/notifications.py
@@ -63,6 +63,7 @@ CADF_TYPE_MAP = {
     'OS-OAUTH1:access_token': taxonomy.SECURITY_CREDENTIAL,
     'OS-OAUTH1:request_token': taxonomy.SECURITY_CREDENTIAL,
     'OS-OAUTH1:consumer': taxonomy.SECURITY_ACCOUNT,
+    'application_credential': taxonomy.SECURITY_CREDENTIAL,
 }
 
 SAML_AUDIT_TYPE = 'http://docs.oasis-open.org/security/saml/v2.0'


### PR DESCRIPTION
Proposed change https://review.opendev.org/#/c/663410/
Worked in Keystone irc to get it fixed, application_credential targets are unknown, this sets them properly. 