### PR TITLE
add possibility to set default tag(s)

### DIFF
--- a/keystone/conf/default.py
+++ b/keystone/conf/default.py
@@ -205,6 +205,17 @@ Default `publisher_id` for outgoing notifications. If left undefined, Keystone
 will default to using the server's host name.
 """))
 
+default_tag = cfg.MultiStrOpt(
+    'default_tag',
+    default=[],
+    help=utils.fmt("""
+Default `tag`(s) for newly created projects. If left undefined, Keystone will
+create projects without an initial tag. This field can be set multiple times in
+order to set multiple default tags, for example:
+default_tag=tag_0
+default_tag=tag_1
+"""))
+
 notification_format = cfg.StrOpt(
     'notification_format',
     default='cadf',
@@ -253,6 +264,7 @@ ALL_OPTS = [
     secure_proxy_ssl_header,
     insecure_debug,
     default_publisher_id,
+    default_tag,
     notification_format,
     notification_opt_out,
 ]

--- a/keystone/resource/core.py
+++ b/keystone/resource/core.py
@@ -201,6 +201,16 @@ class Manager(manager.Manager):
         project['name'] = project['name'].strip()
         project.setdefault('description', '')
 
+        # ccloud add default tag(s)
+        if CONF.default_tag:
+            default_tags = [x.strip() for x in CONF.default_tag]
+            if 'tags' in project:
+                # a user may have provided a tag, which is a default tag, again
+                # make unique by converting to a set
+                project['tags'] = list(set(project['tags'] + default_tags))
+            else:
+                project['tags'] = default_tags
+
         # For regular projects, the controller will ensure we have a valid
         # domain_id. For projects acting as a domain, the project_id
         # is, effectively, the domain_id - and for such projects we don't

--- a/keystone/tests/unit/core.py
+++ b/keystone/tests/unit/core.py
@@ -283,6 +283,10 @@ def new_project_ref(domain_id=None, is_domain=False, **kwargs):
     ref.update(kwargs)
     return ref
 
+def new_project_without_tags_ref(domain_id=None, is_domain=False, **kwargs):
+    ref = new_project_ref(domain_id=domain_id, is_domain=is_domain, **kwargs)
+    ref.pop('tags')
+    return ref
 
 def new_user_ref(domain_id, project_id=None, **kwargs):
     ref = {

--- a/keystone/tests/unit/test_v3_resource.py
+++ b/keystone/tests/unit/test_v3_resource.py
@@ -29,6 +29,9 @@ from keystone.tests.unit import utils as test_utils
 CONF = keystone.conf.CONF
 PROVIDERS = provider_api.ProviderAPIs
 
+_DEFAULT_TAG = ['single_tag']
+_DEFAULT_TAGS = [None, [], ['vc-a-0', 'tag_1', 'tag_2'], _DEFAULT_TAG]
+
 
 class ResourceTestCase(test_v3.RestfulTestCase,
                        test_v3.AssignmentTestMixin):
@@ -729,7 +732,7 @@ class ResourceTestCase(test_v3.RestfulTestCase,
 
         return projects
 
-    def _create_project_and_tags(self, num_of_tags=1):
+    def _create_project_and_tags(self, num_of_tags=1, with_default_tag=False):
         """Create a project and a number of tags attached to that project.
 
         :param num_of_tags: the desired number of tags created with a specified
@@ -739,9 +742,19 @@ class ResourceTestCase(test_v3.RestfulTestCase,
                   random tags
         """
         tags = [uuid.uuid4().hex for i in range(num_of_tags)]
-        ref = unit.new_project_ref(
-            domain_id=self.domain_id,
-            tags=tags)
+
+        if num_of_tags > 0:
+            if with_default_tag:
+                # remove the last tag
+                tags.pop()
+                # add default tag instead
+                tags += _DEFAULT_TAG
+            ref = unit.new_project_ref(
+                domain_id=self.domain_id,
+                tags=tags)
+        else:
+            ref = unit.new_project_without_tags_ref(
+                domain_id=self.domain_id)
         resp = self.post('/projects', body={'project': ref})
         return resp.result['project'], tags
 
@@ -1546,14 +1559,22 @@ class ResourceTestCase(test_v3.RestfulTestCase,
             expected_status=http_client.FORBIDDEN)
 
     def test_create_project_with_tags(self):
-        project, tags = self._create_project_and_tags(num_of_tags=10)
-        ref = self.get(
-            '/projects/%(project_id)s' % {
-                'project_id': project['id']},
-            expected_status=http_client.OK)
-        self.assertIn('tags', ref.result['project'])
-        for tag in tags:
-            self.assertIn(tag, ref.result['project']['tags'])
+        for config_setting in _DEFAULT_TAGS:
+            if config_setting is not None:
+                self.config_fixture.config(default_tag=config_setting)
+            for tag_number in [0, 10]:
+                project, tags = self._create_project_and_tags(
+                    num_of_tags=tag_number, with_default_tag=True)
+                ref = self.get(
+                    '/projects/%(project_id)s' % {
+                        'project_id': project['id']},
+                    expected_status=http_client.OK)
+                self.assertIn('tags', ref.result['project'])
+                for tag in tags:
+                    self.assertIn(tag, ref.result['project']['tags'])
+                if config_setting is not None:
+                    for tag in config_setting:
+                        self.assertIn(tag, ref.result['project']['tags'])
 
     def test_update_project_with_tags(self):
         project, tags = self._create_project_and_tags(num_of_tags=9)


### PR DESCRIPTION
configuration option to set tags that get added to newly created projects

spot testing successful:
- setting undefined without tag like before
- setting one tag works
- setting two tags with repeated option works
- specifying same tag like default tag on project creation works without conflict
- giving additional tags on project creation works