### PR TITLE
Improve performance when listing user's projects in domain

### DIFF
--- a/keystone/resource/core.py
+++ b/keystone/resource/core.py
@@ -881,6 +881,7 @@ class Manager(manager.Manager):
     # NOTE(henry-nash): list_projects_in_domain is actually an internal method
     # and not exposed via the API.  Therefore there is no need to support
     # driver hints for it.
+    @MEMOIZE
     def list_projects_in_domain(self, domain_id):
         return self.driver.list_projects_in_domain(domain_id)
 


### PR DESCRIPTION
This PR improves the performances when listing user's project in domain by caching results of list_projects_in_domain() in resource manager. The function list_prjoects_in_domain() is called multiple times in assignment manager for same domain. 