### PR TITLE
Switch tox to python3

### DIFF
--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -3,8 +3,8 @@ export KEYSTONE_IDENTITY_BACKEND=ldap && \
 export WATCHER_DISABLED=true && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/train-m3/upper-constraints.txt && \
 apt-get update && \
-apt-get install -y build-essential python-pip libpq-dev postgresql-client python3.7 python3.7-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-2.4-2 memcached && \
-pip install tox "six>=1.14.0" && \
+apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3.7 python3.7-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-2.4-2 memcached && \
+pip3 install tox "six>=1.14.0" && \
 /etc/init.d/memcached start && \
 git clone -b stable/train-m3 --single-branch https://github.com/sapcc/keystone.git --depth=1 && \
 cd keystone && \


### PR DESCRIPTION
tox running on python2 causes weird issues with string encoding. Instead
of fixing those issues, switch it to python3