### PR TITLE
Do not filter domain list via projects api with domain-scoped token

### DIFF
--- a/keystone/api/projects.py
+++ b/keystone/api/projects.py
@@ -20,6 +20,7 @@ from six.moves import http_client
 from keystone.common import json_home
 from keystone.common import provider_api
 from keystone.common import rbac_enforcer
+from keystone.common import utils
 from keystone.common import validation
 import keystone.conf
 from keystone import exception
@@ -132,7 +133,16 @@ class ProjectResource(ks_flask.ResourceBase):
             if t in flask.request.args:
                 hints.add_filter(t, flask.request.args[t])
         refs = PROVIDERS.resource_api.list_projects(hints=hints)
-        if self.oslo_context.domain_id:
+
+        # the entries should not be filtered by domain_id if domain list was
+        # requested; otherwise all domains are getting filtered out
+        try:
+            is_domain_requested = utils.attr_as_boolean(
+                flask.request.args['is_domain'])
+        except KeyError:
+            is_domain_requested = False
+
+        if self.oslo_context.domain_id and not is_domain_requested:
             domain_id = self.oslo_context.domain_id
             filtered_refs = [
                 ref for ref in refs if ref['domain_id'] == domain_id

--- a/keystone/tests/unit/test_v3_resource.py
+++ b/keystone/tests/unit/test_v3_resource.py
@@ -1266,6 +1266,40 @@ class ResourceTestCase(test_v3.RestfulTestCase,
         self.assertIn(new_regular_project['id'],
                       [p['id'] for p in r.result['projects']])
 
+    def test_list_projects_is_domain_filter_domain_scoped_token(self):
+        """Call ``GET /projects?is_domain=True/False`` with domain scope"""
+        # grant the domain role to user
+        path = '/domains/%s/users/%s/roles/%s' % (
+            self.domain_id, self.user['id'], self.role['id'])
+        self.put(path=path)
+
+        auth = self.build_authentication_request(
+            user_id=self.user['id'],
+            password=self.user['password'],
+            domain_id=self.domain_id)
+
+        # Check that listing the domains does not result in an empty list
+        new_is_domain_project = unit.new_project_ref(is_domain=True)
+        new_is_domain_project = PROVIDERS.resource_api.create_project(
+            new_is_domain_project['id'], new_is_domain_project)
+
+        r = self.get('/projects?is_domain=True', auth=auth,
+                     expected_status=200)
+        self.assertIn(new_is_domain_project['id'],
+                      [p['id'] for p in r.result['projects']])
+
+        # Check that the projects are still being filtered
+        # The previously created is_domain project is a domain, so
+        # we can reuse it for the project
+        new_regular_project = unit.new_project_ref(
+            is_domain=False, domain_id=new_is_domain_project['id'])
+        new_regular_project = PROVIDERS.resource_api.create_project(
+            new_regular_project['id'], new_regular_project)
+        r = self.get('/projects?is_domain=False', auth=auth,
+                     expected_status=200)
+        self.assertNotIn(new_regular_project['id'],
+                         [p['id'] for p in r.result['projects']])
+
     def test_list_project_is_domain_filter_default(self):
         """Default project list should not see projects acting as domains."""
         # Get the initial count of regular projects


### PR DESCRIPTION
If project list is requested via /v3/projects with domain-scoped
token, only the project in the domain are being returned. It makes no
sense when is_domain filter is used, because domains are top-level the
request always returned an empty list.

Return domain list the same way as if /v3/domains is being used and do
not filter out anything. Note: the policies still need to be adjusted by
the operators if they wish to allow this kind of request.

Closes-Bug: 1950325
Change-Id: I77ed200d1a222659abd1e2f00b9984647b310c43