### PR TITLE
Maintain dnspython in custom-requirements.txt

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -3,6 +3,7 @@ git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middle
 git+https://github.com/funkyHat/py-radius@install_requires#egg=py-radius
 git+https://github.com/sapcc/keystone-extensions.git@train#egg=keystone-extensions
 git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
+git+https://github.com/sapcc/dnspython.git@ccloud#egg=dnspython
 
 # needs for osprofiler
 jaeger-client

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist = py27,py37,pep8,api-ref,docs,genconfig,genpolicy,releasenotes,protectio
 usedevelop = True
 install_command = pip install {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
-deps = -c{env:UPPER_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/train}
+deps = -c{env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/train-m3/upper-constraints.txt}
        -r{toxinidir}/test-requirements.txt
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/custom-requirements.txt


### PR DESCRIPTION
As it's been removed from `upper-constraints.txt` to accomodate
`pip>=20.3` -
https://github.com/sapcc/requirements/commit/9b371755f54fbc54bbe67953e8bf1e81be0744ae
(https://github.com/sapcc/requirements/commit/956b1d94c3448f95dd90714857f8c4ebef3c88d5)
