### PR TITLE
Pull keystone-extensions.git@stable/zed-m3 instead of just zed

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven[flask]
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
 git+https://github.com/funkyHat/py-radius@install_requires#egg=py-radius
-git+https://github.com/sapcc/keystone-extensions.git@zed#egg=keystone-extensions
+git+https://github.com/sapcc/keystone-extensions.git@stable/zed-m3#egg=keystone-extensions
 git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
 
 # needs for osprofiler


### PR DESCRIPTION
This follows the standard naming convention.