### PR TITLE
Revert "Log the traceback in _handle_keystone_exception"

### DIFF
--- a/keystone/server/flask/application.py
+++ b/keystone/server/flask/application.py
@@ -88,8 +88,10 @@ def _handle_keystone_exception(error):
         LOG.warning(
             "Authorization failed. %(exception)s from %(remote_addr)s",
             {'exception': error, 'remote_addr': flask.request.remote_addr})
-    else:
+    elif isinstance(error, exception.UnexpectedError):
         LOG.exception(str(error))
+    else:
+        LOG.warning(str(error))
 
     # Render the exception to something user "friendly"
     error_message = error.args[0]


### PR DESCRIPTION
This reverts commit 3f628a9ae4857e3c48b7228ad77ea980ec824ef9.

This is needed, because the exceptions are very loud and may easily flood sentry. See https://bugs.launchpad.net/keystone/+bug/2045995 for more details. This revert should be reverted after upstream fixes the issue properly.

Change-Id: I3ded1c81f3e9235be8e1655bcb772f26294d72a8