### PR TITLE
Correct format for token expiration time

### DIFF
--- a/keystone/tests/unit/test_v3_auth.py
+++ b/keystone/tests/unit/test_v3_auth.py
@@ -5583,9 +5583,12 @@ class ApplicationCredentialAuth(test_v3.RestfulTestCase):
         app_cred_ref = self.app_cred_api.create_application_credential(
             app_cred)
         auth_data = self.build_authentication_request(
-            app_cred_id=app_cred_ref['id'], secret=app_cred_ref['secret'])
-        resp = self.v3_create_token(auth_data,
-                                    expected_status=http.client.CREATED)
+            app_cred_id=app_cred_ref['id'], secret=app_cred_ref['secret']
+        )
+        resp = self.v3_create_token(
+            auth_data, expected_status=http.client.CREATED
+        )
+        self.assertValidTokenResponse(resp)
         token = resp.headers.get('X-Subject-Token')
         future = datetime.datetime.utcnow() + datetime.timedelta(minutes=2)
         with freezegun.freeze_time(future):

--- a/keystone/token/provider.py
+++ b/keystone/token/provider.py
@@ -278,11 +278,16 @@ class Manager(manager.Manager):
             token_time = timeutils.normalize_time(
                 timeutils.parse_isotime(token.expires_at))
             if (app_cred['expires_at'] is not None) and (
-                    token_time > app_cred['expires_at']):
-                token.expires_at = app_cred['expires_at'].isoformat()
-                LOG.debug('Resetting token expiration to the application'
-                          ' credential expiration: %s',
-                          app_cred['expires_at'].isoformat())
+                token_time > app_cred['expires_at']
+            ):
+                token.expires_at = utils.isotime(
+                    app_cred['expires_at'], subsecond=True
+                )
+                LOG.debug(
+                    'Resetting token expiration to the application'
+                    ' credential expiration: %s',
+                    token.expires_at,
+                )
 
         token_id, issued_at = self.driver.generate_id_and_issued_at(token)
         token.mint(token_id, issued_at)


### PR DESCRIPTION
Tokens with expiration time limited by application credentials had an incorrect format.

Fix the format, control it with the test.

Closes-Bug: 2075723
Change-Id: I09fe34541615090766a5c4a010a3f39756debedc