### PR TITLE
Gracefully disallow reauth with app-creds-bound token

### DIFF
--- a/keystone/api/_shared/authentication.py
+++ b/keystone/api/_shared/authentication.py
@@ -209,7 +209,21 @@ def authenticate_for_token(auth=None):
         app_cred_id = None
         if 'application_credential' in method_names:
             token_auth = auth_info.auth['identity']
-            app_cred_id = token_auth['application_credential']['id']
+            try:
+                app_cred_id = token_auth['application_credential']['id']
+            except KeyError:
+                # NOTE(bbobrov): see bug #1878438 on launchpad.
+                # There is no any good fix for it, at least with the current
+                # architecture. Lets just return a nice message that this
+                # is currently not supported.
+                LOG.warning(
+                    'Unsupported reauthentication attempt with a token '
+                    'after authenticating with application credentials'
+                )
+                raise exception.Unauthorized(
+                    _('Cannot reauthenticate with a token issued with '
+                      'application credentials')
+                )
 
         # Do MFA Rule Validation for the user
         if not core.UserMFARulesValidator.check_auth_methods_against_rules(


### PR DESCRIPTION
Due to architectural reasons, bug https://bugs.launchpad.net/keystone/+bug/1878438 appeared. There is no good way to fix it, upstream also cannot get to it. If someone hits the bug, they get error 500 and keystone crashes.

Fix this hard crash and return an Unauthorized response instead. This will not break any existing usecases, because things are not working already. This change should be reverted after upstream fixes the bug.

Change-Id: I0d7802ddcdef7646f43fd57a0cf9ae94686d58e9