### PR TITLE
Disable rate-limiting middleware

### DIFF
--- a/keystone/server/flask/core.py
+++ b/keystone/server/flask/core.py
@@ -78,13 +78,13 @@ _CC_MIDDLEWARE = (
                 ep='lifesaver',
                 conf={}),
     # CCloud: add rate_limit middleware
-    _Middleware(namespace='rate_limit.middleware',
-                ep='rate-limit',
-                conf={'config_file': '/etc/keystone/ratelimit.yaml',
-                      'service_type': 'identity',
-                      'rate_limit_by': 'initiator_project_id',
-                      'backend_host': 'keystone-sapcc-rate-limit',
-                      'backend_timeout_seconds': '1'}),
+    #_Middleware(namespace='rate_limit.middleware',
+    #            ep='rate-limit',
+    #            conf={'config_file': '/etc/keystone/ratelimit.yaml',
+    #                  'service_type': 'identity',
+    #                  'rate_limit_by': 'initiator_project_id',
+    #                  'backend_host': 'keystone-sapcc-rate-limit',
+    #                  'backend_timeout_seconds': '1'}),
 )
 
 # NOTE(morgan): ORDER HERE IS IMPORTANT! Each of these middlewares are


### PR DESCRIPTION
The ratelimiting middleware seems to bring more maintainance than use, which is why it should be disabled until we figure out how to properly set it up.