### PR TITLE
Cherry-pick: Support emitting partial hash of invalid password

### DIFF
--- a/keystone/common/password_hashing.py
+++ b/keystone/common/password_hashing.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import base64
+import hmac
 import itertools
 
 from oslo_log import log
@@ -156,3 +158,34 @@ def hash_password(password):
             params['salt_size'] = CONF.identity.salt_bytesize
 
     return hasher.using(**params).hash(password_utf8)
+
+def generate_partial_password_hash(password: str, salt: str) -> str:
+    """Generates partial password hash for reporting purposes.
+
+    The generated password hash is base64 encoded, and `max_chars` of it are
+    returned.
+    """
+    secret_key = CONF.security_compliance.invalid_password_hash_secret_key
+    if secret_key is None:
+        raise RuntimeError(_('Secret Key value has to be provided'))
+
+    hash_function = CONF.security_compliance.invalid_password_hash_function
+
+    salted = hmac.digest(
+        key=bytes(salt, "utf-8"),
+        msg=bytes(password, "utf-8"),
+        digest=hash_function,
+    )
+
+    peppered = hmac.digest(
+        key=bytes(secret_key, "utf-8"), msg=salted, digest=hash_function
+    )
+
+    # encode to utilize more characters to reduce collisions when further
+    # truncating
+    encoded = base64.b64encode(peppered).decode("utf-8").rstrip("=")
+
+    max_chars = CONF.security_compliance.invalid_password_hash_max_chars
+    if max_chars is None:
+        return encoded
+    return encoded[:max_chars]

--- a/keystone/conf/security_compliance.py
+++ b/keystone/conf/security_compliance.py
@@ -124,6 +124,79 @@ update user API. This feature is disabled by default. This feature is only
 applicable with the `sql` backend for the `[identity] driver`.
 """))
 
+report_invalid_password_hash = cfg.ListOpt(
+    'report_invalid_password_hash',
+    default="",
+    sample_default="event",
+    item_type=cfg.types.String(
+        choices=[
+            (
+                "event",
+                utils.fmt("""
+Enriches `identity.authenticate.failure` event notifications with partial
+invalid password hash
+"""),
+            )
+            # ("log", "description"),
+        ]
+    ),
+    help=utils.fmt(
+        """
+When configured, enriches the corresponding output channel with hash of invalid
+password, which could be further used to distinguish bruteforce attacks from
+e.g. external user automations that did not timely update rotated password by
+analyzing variability of the hash value.
+Additional configuration parameters are available using other
+`invalid_password_hash_*` configuration entires, that only take effect when
+this option is activated.
+"""
+    ),
+)
+
+invalid_password_hash_secret_key = cfg.StrOpt(
+    'invalid_password_hash_secret_key',
+    secret=True,
+    help=utils.fmt(
+        """
+If `report_invalid_password_hash` is configured, uses provided secret key when
+generating password hashes to make them unique and distinct from any other
+Keystone installations out there. Should be some secret static value specific
+to the current installation (the same value should be used in distributed
+installations working with the same backend, to make them all generate equal
+hashes for equal invalid passwords). 16 bytes (128 bits) or more is
+recommended.
+"""
+    ),
+)
+
+invalid_password_hash_function = cfg.StrOpt(
+    'invalid_password_hash_function',
+    default='sha256',
+    help=utils.fmt(
+        """
+If `report_invalid_password_hash` is configured, defines the hash function to
+be used by HMAC. Possible values are names suitable to hashlib.new() -
+https://docs.python.org/3/library/hashlib.html#hashlib.new.
+"""
+    ),
+)
+
+invalid_password_hash_max_chars = cfg.IntOpt(
+    'invalid_password_hash_max_chars',
+    min=1,
+    sample_default=5,
+    help=utils.fmt(
+        """
+If `report_invalid_password_hash` is configured, defines the number of
+characters of hash of invalid password to be returned. When not specified,
+returns full hash. Its length depends on implementation and
+`invalid_password_hash_function` configuration, but is typically 16+
+characters. It's recommended to use the least reasonable value however - it's
+the most effective measure to protect the hashes.
+"""
+    ),
+)
+
 
 GROUP_NAME = __name__.split('.')[-1]
 ALL_OPTS = [
@@ -135,7 +208,11 @@ ALL_OPTS = [
     minimum_password_age,
     password_regex,
     password_regex_description,
-    change_password_upon_first_use
+    change_password_upon_first_use,
+    report_invalid_password_hash,
+    invalid_password_hash_secret_key,
+    invalid_password_hash_function,
+    invalid_password_hash_max_chars,
 ]
 
 

--- a/keystone/notifications.py
+++ b/keystone/notifications.py
@@ -24,6 +24,7 @@ from oslo_log import log
 import oslo_messaging
 from oslo_utils import reflection
 import pycadf
+from pycadf import attachment
 from pycadf import cadftaxonomy as taxonomy
 from pycadf import cadftype
 from pycadf import credential
@@ -33,6 +34,7 @@ from pycadf import reason
 from pycadf import resource
 
 from keystone.common import context
+from keystone.common import password_hashing
 from keystone.common import provider_api
 from keystone.common import utils
 import keystone.conf
@@ -591,11 +593,49 @@ class CadfNotificationWrapper(object):
                 if isinstance(ex, exception.AccountLocked):
                     raise exception.Unauthorized
                 raise
-            except Exception:
+            except Exception as ex:
+                audit_kwargs = {}
+
+                if (
+                    isinstance(ex, AssertionError)
+                    and kwargs.get("password") is not None
+                    and "event"
+                    in CONF.security_compliance.report_invalid_password_hash
+                ):
+                    # Authentication failed because of invalid password, so we
+                    # include partial pasword hash to aid bruteforce attacks
+                    # recognition
+                    partial_password_hash = (
+                        password_hashing.generate_partial_password_hash(
+                            kwargs["password"],
+                            # use fully qualified class name of the driver as
+                            # personalization salt causing to produce different
+                            # hashes for different backends even when the same
+                            # invalid password is submitted
+                            salt=reflection.get_class_name(
+                                wrapped_self.driver
+                            ),
+                        )
+                    )
+                    attachments = audit_kwargs.get("attachments", [])
+                    attachments.append(
+                        attachment.Attachment(
+                            typeURI="mime:text/plain",
+                            content=partial_password_hash,
+                            name="partial_password_hash",
+                        )
+                    )
+                    audit_kwargs["attachments"] = attachments
+
                 # For authentication failure send a CADF event as well
-                _send_audit_notification(self.action, initiator,
-                                         taxonomy.OUTCOME_FAILURE,
-                                         target, self.event_type)
+                _send_audit_notification(
+                    self.action,
+                    initiator,
+                    taxonomy.OUTCOME_FAILURE,
+                    target,
+                    self.event_type,
+                    **audit_kwargs,
+                )
                 raise
             else:
                 _send_audit_notification(self.action, initiator,
@@ -744,8 +784,16 @@ class _CatalogHelperObj(provider_api.ProviderAPIMixin, object):
     """A helper object to allow lookups of identity service id."""
 
 
-def _send_audit_notification(action, initiator, outcome, target,
-                             event_type, reason=None, **kwargs):
+def _send_audit_notification(
+    action,
+    initiator,
+    outcome,
+    target,
+    event_type,
+    reason=None,
+    attachments=None,
+    **kwargs,
+):
     """Send CADF notification to inform observers about the affected resource.
 
     This method logs an exception when sending the notification fails.
@@ -761,6 +809,7 @@ def _send_audit_notification(action, initiator, outcome, target,
         key-value pairs to the CADF event.
     :param reason: Reason for the notification which contains the response
         code and message description
+    :param attachments: Array of Attachment objects
     """
     if _check_notification_opt_out(event_type, outcome):
         return
@@ -789,6 +838,10 @@ def _send_audit_notification(action, initiator, outcome, target,
 
     if service_id is not None:
         event.observer.id = service_id
+
+    attachments = attachments if attachments is not None else []
+    for attachment_val in attachments:
+        event.add_attachment(attachment_val)
 
     for key, value in kwargs.items():
         setattr(event, key, value)

--- a/keystone/tests/unit/common/test_notifications.py
+++ b/keystone/tests/unit/common/test_notifications.py
@@ -24,6 +24,7 @@ from oslo_log import log
 import oslo_messaging
 from pycadf import cadftaxonomy
 from pycadf import cadftype
+from pycadf import event as cadfevent
 from pycadf import eventfactory
 from pycadf import resource as cadfresource
 
@@ -264,8 +265,16 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
         self.useFixture(fixtures.MockPatchObject(
             notifications, '_send_notification', fake_notify))
 
-        def fake_audit(action, initiator, outcome, target,
-                       event_type, reason=None, **kwargs):
+        def fake_audit(
+            action,
+            initiator,
+            outcome,
+            target,
+            event_type,
+            reason=None,
+            attachments=None,
+            **kwargs,
+        ):
             service_security = cadftaxonomy.SERVICE_SECURITY
 
             event = eventfactory.EventFactory().new_event(
@@ -276,6 +285,10 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
                 target=target,
                 reason=reason,
                 observer=cadfresource.Resource(typeURI=service_security))
+
+            attachments = attachments if attachments is not None else []
+            for attachment_val in attachments:
+                event.add_attachment(attachment_val)
 
             for key, value in kwargs.items():
                 setattr(event, key, value)
@@ -309,8 +322,15 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
             self.assertEqual(actor_type, note['actor_type'])
             self.assertEqual(actor_operation, note['actor_operation'])
 
-    def _assert_last_audit(self, resource_id, operation, resource_type,
-                           target_uri, reason=None):
+    def _assert_last_audit(
+        self,
+        resource_id,
+        operation,
+        resource_type,
+        target_uri,
+        reason=None,
+        attachments=None,
+    ):
         # NOTE(stevemar): If 'cadf' format is not used, then simply
         # return since this assertion is not valid.
         if CONF.notification_format != 'cadf':
@@ -335,6 +355,15 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
             self.assertEqual(reason['reasonType'],
                              payload['reason']['reasonType'])
         self.assertTrue(audit['send_notification_called'])
+        if attachments is None:
+            self.assertNotIn(cadfevent.EVENT_KEYNAME_ATTACHMENTS, payload)
+        else:
+            self.assertIn(cadfevent.EVENT_KEYNAME_ATTACHMENTS, payload)
+            for attachment_val in attachments:
+                self.assertIn(
+                    attachment_val,
+                    payload.get(cadfevent.EVENT_KEYNAME_ATTACHMENTS),
+                )
 
     def _assert_initiator_data_is_set(self, operation, resource_type, typeURI):
         self.assertGreater(len(self._audits), 0)
@@ -911,6 +940,131 @@ class CADFNotificationsForPCIDSSEvents(BaseNotificationTest):
         self._assert_last_audit(user_ref['id'], UPDATED_OPERATION, 'user',
                                 cadftaxonomy.SECURITY_ACCOUNT_USER,
                                 reason=expected_reason)
+
+    def test_valid_password_not_hashed_by_default(self):
+        password = uuid.uuid4().hex
+        user_ref = unit.new_user_ref(
+            domain_id=self.domain_id, password=password
+        )
+        user_ref = PROVIDERS.identity_api.create_user(user_ref)
+
+        with mock.patch(
+            'keystone.common.password_hashing.generate_partial_password_hash'
+        ) as mocked:
+            with self.make_request():
+                PROVIDERS.identity_api.authenticate(user_ref['id'], password)
+            mocked.assert_not_called()
+
+        self._assert_last_audit(
+            None,
+            'authenticate',
+            None,
+            cadftaxonomy.ACCOUNT_USER,
+            attachments=None,
+        )
+
+    def test_invalid_password_not_hashed_by_default(self):
+        password = uuid.uuid4().hex
+        invalid_password = 'invalid_' + password
+        user_ref = unit.new_user_ref(
+            domain_id=self.domain_id, password=password
+        )
+        user_ref = PROVIDERS.identity_api.create_user(user_ref)
+
+        with mock.patch(
+            'keystone.common.password_hashing.generate_partial_password_hash'
+        ) as mocked:
+            with self.make_request():
+                self.assertRaises(
+                    AssertionError,
+                    PROVIDERS.identity_api.authenticate,
+                    user_id=user_ref['id'],
+                    password=invalid_password,
+                )
+            mocked.assert_not_called()
+
+        self._assert_last_audit(
+            None,
+            'authenticate',
+            None,
+            cadftaxonomy.ACCOUNT_USER,
+            attachments=None,
+        )
+
+    def test_valid_password_hash_not_included_when_report_in_event(self):
+        password = uuid.uuid4().hex
+        user_ref = unit.new_user_ref(
+            domain_id=self.domain_id, password=password
+        )
+        user_ref = PROVIDERS.identity_api.create_user(user_ref)
+
+        conf = self.useFixture(config_fixture.Config(CONF))
+        conf.config(
+            group='security_compliance', report_invalid_password_hash='event'
+        )
+        conf.config(
+            group='security_compliance',
+            invalid_password_hash_secret_key='secret_key',
+        )
+        with mock.patch(
+            'keystone.common.password_hashing.generate_partial_password_hash'
+        ) as mocked:
+            with self.make_request():
+                PROVIDERS.identity_api.authenticate(user_ref['id'], password)
+            mocked.assert_not_called()
+
+        self._assert_last_audit(
+            None,
+            'authenticate',
+            None,
+            cadftaxonomy.ACCOUNT_USER,
+            attachments=None,
+        )
+
+    def test_invalid_password_hash_included_when_report_in_event(self):
+        password = uuid.uuid4().hex
+        invalid_password = 'invalid_' + password
+        user_ref = unit.new_user_ref(
+            domain_id=self.domain_id, password=password
+        )
+        user_ref = PROVIDERS.identity_api.create_user(user_ref)
+
+        conf = self.useFixture(config_fixture.Config(CONF))
+        conf.config(
+            group='security_compliance', report_invalid_password_hash='event'
+        )
+        conf.config(
+            group='security_compliance',
+            invalid_password_hash_secret_key='secret_key',
+        )
+        hashed_invalid_password = 'hashed_' + invalid_password
+        with mock.patch(
+            'keystone.common.password_hashing.generate_partial_password_hash',
+            return_value=hashed_invalid_password,
+        ) as mocked:
+            with self.make_request():
+                self.assertRaises(
+                    AssertionError,
+                    PROVIDERS.identity_api.authenticate,
+                    user_id=user_ref['id'],
+                    password=invalid_password,
+                )
+
+            mocked.assert_called_once()
+
+        self._assert_last_audit(
+            None,
+            'authenticate',
+            None,
+            cadftaxonomy.ACCOUNT_USER,
+            attachments=[
+                {
+                    'content': hashed_invalid_password,
+                    'name': "partial_password_hash",
+                    'typeURI': "mime:text/plain",
+                }
+            ],
+        )
 
 
 class CADFNotificationsForEntities(NotificationsForEntities):

--- a/keystone/tests/unit/common/test_password_hashing.py
+++ b/keystone/tests/unit/common/test_password_hashing.py
@@ -1,0 +1,177 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oslo_config import fixture as config_fixture
+
+from keystone.common import password_hashing
+import keystone.conf
+from keystone.tests import unit
+
+CONF = keystone.conf.CONF
+
+
+class TestGeneratePartialPasswordHash(unit.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.h = password_hashing.generate_partial_password_hash
+
+        self.config_fixture = self.useFixture(config_fixture.Config(CONF))
+        self.config_fixture.config(
+            group="security_compliance",
+            invalid_password_hash_secret_key="secret_key",
+        )
+
+    def test_equal_input_generates_equal_hash(self):
+        args1 = ("password", "salt")
+        args2 = ("password", "salt")
+
+        hashed1 = self.h(*args1)
+        hashed2 = self.h(*args2)
+
+        self.assertEqual(hashed1, hashed2)
+
+    def test_different_inputs_generate_different_hashes(self):
+        params = [
+            {
+                "msg": "Different passwords",
+                "args1": ("password1", "salt"),
+                "args2": ("password2", "salt"),
+            },
+            {
+                "msg": "Different salts",
+                "args1": ("password", "salt1"),
+                "args2": ("password", "salt2"),
+            },
+            {
+                "msg": "Same but mixed inputs",
+                "args1": ("password", "salt"),
+                "args2": ("salt", "password"),
+            },
+        ]
+
+        # test variability of: a) full hash; b) partial hash
+        max_chars_conf = [None, 5]
+        for data in params:
+            for max_chars in max_chars_conf:
+                msg = data["msg"] + f" ({max_chars=})"
+                self.config_fixture.config(
+                    group="security_compliance",
+                    invalid_password_hash_max_chars=max_chars,
+                )
+                with self.subTest(msg=msg):
+                    hashed1 = self.h(*data["args1"])
+                    hashed2 = self.h(*data["args2"])
+                    self.assertNotEqual(hashed1, hashed2, msg=msg)
+
+    def test_generates_full_hash_by_default(self):
+        args1 = ("password", "salt")
+        args2 = ("password", "salt")
+
+        # when `max_chars` is not specified, a default value will be used,
+        # which is expected to return full hash
+        hashed1 = self.h(*args1)
+
+        self.config_fixture.config(
+            group="security_compliance",
+            # 1000 is larger than any supported hash function key length +
+            # base64 encoding, so it should cause full hash to be returned
+            invalid_password_hash_max_chars=1000,
+        )
+        hashed2 = self.h(*args2)
+
+        self.assertEqual(len(hashed1), len(hashed2))
+
+    def test_invalid_function_raises_value_error(self):
+        args = ("password", "salt")
+        self.config_fixture.config(
+            group="security_compliance",
+            invalid_password_hash_function="invalid",
+        )
+
+        self.assertRaises(ValueError, self.h, *args)
+
+    def test_large_passwords(self):
+        # 48042 bytes or 48 kB
+        args1 = ("p" * 1000 * 48 + "1", "salt")
+        args2 = ("p" * 1000 * 48 + "2", "salt")
+
+        # test variability of: a) full hash; b) partial hash
+        max_chars_conf = [None, 5]
+        for max_chars in max_chars_conf:
+            msg = f"Large password ({max_chars=})"
+            self.config_fixture.config(
+                group="security_compliance",
+                invalid_password_hash_max_chars=max_chars,
+            )
+            with self.subTest(msg=msg):
+                hashed1 = self.h(*args1)
+                hashed2 = self.h(*args2)
+                self.assertNotEqual(hashed1, hashed2, msg=msg)
+
+    def test_different_conf_generates_different_hashes(self):
+        args = ("password", "salt")
+
+        params = [
+            {
+                "msg": "Different secret_keys",
+                "conf1": {"invalid_password_hash_secret_key": "secret_key1"},
+                "conf2": {"invalid_password_hash_secret_key": "secret_key2"},
+            },
+            {
+                "msg": "Different max chars",
+                "conf1": {"invalid_password_hash_max_chars": 3},
+                "conf2": {"invalid_password_hash_max_chars": 4},
+            },
+            {
+                "msg": "Different hash functions",
+                "conf1": {"invalid_password_hash_function": "sha3_512"},
+                "conf2": {"invalid_password_hash_function": "sha512"},
+            },
+        ]
+
+        for data in params:
+            with self.subTest(msg=data["msg"]):
+                self.config_fixture.config(
+                    group="security_compliance", **data["conf1"]
+                )
+                hashed1 = self.h(*args)
+                self.config_fixture.config(
+                    group="security_compliance", **data["conf2"]
+                )
+                hashed2 = self.h(*args)
+                self.assertNotEqual(hashed1, hashed2, msg=data["msg"])
+
+    def test_conf_secret_key_is_required(self):
+        self.config_fixture.config(
+            group="security_compliance", invalid_password_hash_secret_key=None
+        )
+
+        args = ("password", "salt")
+
+        self.assertRaises(RuntimeError, self.h, *args)
+
+    def test_returns_not_more_than_max_chars(self):
+        args = ("password", "salt")
+
+        max_chars_conf = [1, 5, 1000]
+        for max_chars in max_chars_conf:
+            self.config_fixture.config(
+                group="security_compliance",
+                invalid_password_hash_max_chars=max_chars,
+            )
+            with self.subTest(msg=max_chars):
+                hashed = self.h(*args)
+
+                self.assertLessEqual(
+                    len(hashed), max_chars, msg=f"{max_chars=}"
+                )

--- a/releasenotes/notes/pci-dss-invalid-password-reporting-975955d2d79c21b3.yaml
+++ b/releasenotes/notes/pci-dss-invalid-password-reporting-975955d2d79c21b3.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    `bug 2060972 <https://bugs.launchpad.net/keystone/+bug/2060972>`_
+    Added new configuration option ``[security_compliance]
+    report_invalid_password_hash`` to enable and configure reporting of hashes
+    of submitted invalid passwords, which could be used to facilitate analysis
+    of failed login attempts (as per PCI DSS requirements). The corresponding
+    Keystone specification - `Include invalid password details in audit
+    messages <https://specs.openstack.org/openstack/keystone-specs/specs/keystone/2025.1/pci-dss-invalid-password-reporting.html>`_.


### PR DESCRIPTION
This is a cherry-pick of https://review.opendev.org/c/openstack/keystone/+/932423, with formatting preferred to the upstream.

I didn't manage to run tests locally on my macOS machine because of [LDAP/pyldap issues](https://github.com/python-ldap/python-ldap/issues/359) I didn't manage to sort out for the fork.

```
.tox/py3/lib/python3.11/site-packages/_ldap.cpython-311-darwin.so, 0x0002): symbol not found in flat namespace '_ldap_init_fd'
```

The solution I was typically applying to get it running in the recent upstream versions (with `py312`) was:

```
export \
  LDFLAGS="-L$(brew --prefix openssl)/lib \
           -L$(brew --prefix openldap)/lib" \
  CFLAGS="-I$(brew --prefix openssl)/include \
          -I$(brew --prefix openldap)/include"
.tox/py3/bin/pip uninstall python-ldap --yes \
&& .tox/py3/bin/pip install python-ldap \
  --global-option=build_ext \
  --global-option="-I$(xcrun --show-sdk-path)/usr/include/sasl" \
  --no-deps --force-reinstall --no-cache-dir
```

But it's not helping in the fork with neither `py310` nor `py311` (and not building with `py312`).