### PR TITLE
Add python-binary-memcached package

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,3 +1,5 @@
+python-binary-memcached
+
 git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven[flask]
 git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middleware
 git+https://github.com/funkyHat/py-radius@install_requires#egg=py-radius


### PR DESCRIPTION
Install the python-binary-memcached package into the Keystone image

SALS works only over a binary protocol, and it can only work with `dogpile.cache.bmemcached` backend, which requires pip package `python-binary-memcached` to be present.