### PR TITLE
Add service user authentication to ec2 and s3 endpoints

### DIFF
--- a/doc/source/getting-started/policy_mapping.rst
+++ b/doc/source/getting-started/policy_mapping.rst
@@ -245,6 +245,8 @@ identity:delete_application_credential                     DELETE /v3/users/{use
 identity:get_access_rule                                   GET /v3/users/{user_id}/access_rules/{access_rule_id}
 identity:list_access_rules                                 GET /v3/users/{user_id}/access_rules
 identity:delete_access_rule                                DELETE /v3/users/{user_id}/access_rules/{access_rule_id}
+identity:s3tokens_validate                                 POST /v3/s3tokens
+identity:ec2tokens_validate                                POST /v3/es2tokens
 
 =========================================================  ===
 

--- a/keystone/common/policies/__init__.py
+++ b/keystone/common/policies/__init__.py
@@ -22,6 +22,7 @@ from keystone.common.policies import credential
 from keystone.common.policies import domain
 from keystone.common.policies import domain_config
 from keystone.common.policies import ec2_credential
+from keystone.common.policies import ec2tokens
 from keystone.common.policies import endpoint
 from keystone.common.policies import endpoint_group
 from keystone.common.policies import grant
@@ -40,6 +41,7 @@ from keystone.common.policies import registered_limit
 from keystone.common.policies import revoke_event
 from keystone.common.policies import role
 from keystone.common.policies import role_assignment
+from keystone.common.policies import s3tokens
 from keystone.common.policies import service
 from keystone.common.policies import service_provider
 from keystone.common.policies import token
@@ -78,6 +80,8 @@ def list_rules():
         revoke_event.list_rules(),
         role.list_rules(),
         role_assignment.list_rules(),
+        s3tokens.list_rules(),
+        ec2tokens.list_rules(),
         service.list_rules(),
         service_provider.list_rules(),
         token_revocation.list_rules(),

--- a/keystone/common/policies/ec2tokens.py
+++ b/keystone/common/policies/ec2tokens.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oslo_policy import policy
+
+from keystone.common.policies import base
+
+# Align EC2 tokens API with S3 tokens: require admin or service users
+ADMIN_OR_SERVICE = 'rule:service_or_admin'
+
+
+ec2tokens_policies = [
+    policy.DocumentedRuleDefault(
+        name=base.IDENTITY % 'ec2tokens_validate',
+        check_str=ADMIN_OR_SERVICE,
+        scope_types=['system', 'domain', 'project'],
+        description='Validate EC2 credentials and create a Keystone token. '
+        'Restricted to service users or administrators.',
+        operations=[{'path': '/v3/ec2tokens', 'method': 'POST'}],
+    )
+]
+
+
+def list_rules():
+    return ec2tokens_policies

--- a/keystone/common/policies/s3tokens.py
+++ b/keystone/common/policies/s3tokens.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from oslo_policy import policy
+
+from keystone.common.policies import base
+
+# S3 tokens API requires service authentication to prevent presigned URL exploitation
+# This policy restricts access to service users or administrators only
+ADMIN_OR_SERVICE = 'rule:service_or_admin'
+
+s3tokens_policies = [
+    policy.DocumentedRuleDefault(
+        name=base.IDENTITY % 's3tokens_validate',
+        check_str=ADMIN_OR_SERVICE,
+        scope_types=['system', 'domain', 'project'],
+        description='Validate S3 credentials and create a Keystone token. '
+        'Restricted to service users or administrators to prevent '
+        'exploitation via presigned URLs.',
+        operations=[{'path': '/v3/s3tokens', 'method': 'POST'}],
+    )
+]
+
+
+def list_rules():
+    return s3tokens_policies

--- a/keystone/tests/unit/test_contrib_ec2_core.py
+++ b/keystone/tests/unit/test_contrib_ec2_core.py
@@ -44,7 +44,7 @@ class EC2ContribCoreV3(test_v3.RestfulTestCase):
         self.assertEqual(http.client.METHOD_NOT_ALLOWED,
                          resp.status_code)
 
-    def test_valid_authentication_response_with_proper_secret(self):
+    def _test_valid_authentication_response_with_proper_secret(self, **kwargs):
         signer = ec2_utils.Ec2Signer(self.cred_blob['secret'])
         timestamp = utils.isotime(timeutils.utcnow())
         credentials = {
@@ -63,8 +63,16 @@ class EC2ContribCoreV3(test_v3.RestfulTestCase):
         resp = self.post(
             '/ec2tokens',
             body={'credentials': credentials},
-            expected_status=http.client.OK)
+            expected_status=http.client.OK,
+            **kwargs)
         self.assertValidProjectScopedTokenResponse(resp, self.user)
+
+    def test_valid_authentication_response_with_proper_secret(self):
+        self._test_valid_authentication_response_with_proper_secret()
+
+    def test_valid_authentication_response_with_proper_secret_noauth(self):
+        self._test_valid_authentication_response_with_proper_secret(
+            noauth=True)
 
     def test_valid_authentication_response_with_signature_v4(self):
         signer = ec2_utils.Ec2Signer(self.cred_blob['secret'])

--- a/keystone/tests/unit/test_contrib_ec2_core.py
+++ b/keystone/tests/unit/test_contrib_ec2_core.py
@@ -60,19 +60,35 @@ class EC2ContribCoreV3(test_v3.RestfulTestCase):
             },
         }
         credentials['signature'] = signer.generate(credentials)
+        # Authenticate as system admin by default unless overridden via kwargs
+        token = None
+        if 'noauth' in kwargs and kwargs['noauth']:
+            token = None
+        else:
+            PROVIDERS.assignment_api.create_system_grant_for_user(
+                self.user_id, self.role_id
+            )
+            token = self.get_system_scoped_token()
+
+        expected_status = kwargs.get('expected_status', http.client.OK)
         resp = self.post(
             '/ec2tokens',
             body={'credentials': credentials},
-            expected_status=http.client.OK,
-            **kwargs)
-        self.assertValidProjectScopedTokenResponse(resp, self.user)
+            expected_status=expected_status,
+            token=token,
+            noauth=kwargs.get('noauth'),
+        )
+        if expected_status == http.client.OK:
+            self.assertValidProjectScopedTokenResponse(resp, self.user)
 
     def test_valid_authentication_response_with_proper_secret(self):
         self._test_valid_authentication_response_with_proper_secret()
 
     def test_valid_authentication_response_with_proper_secret_noauth(self):
+        # ec2 endpoint now enforces RBAC; unauthenticated should be denied
         self._test_valid_authentication_response_with_proper_secret(
-            noauth=True)
+            expected_status=http.client.UNAUTHORIZED, noauth=True
+        )
 
     def test_valid_authentication_response_with_signature_v4(self):
         signer = ec2_utils.Ec2Signer(self.cred_blob['secret'])

--- a/keystone/tests/unit/test_contrib_s3_core.py
+++ b/keystone/tests/unit/test_contrib_s3_core.py
@@ -46,7 +46,7 @@ class S3ContribCore(test_v3.RestfulTestCase):
         self.assertEqual(http.client.METHOD_NOT_ALLOWED,
                          resp.status_code)
 
-    def test_good_response(self):
+    def _test_good_response(self, **kwargs):
         sts = 'string to sign'  # opaque string from swift3
         sig = hmac.new(self.cred_blob['secret'].encode('ascii'),
                        sts.encode('ascii'), hashlib.sha1).digest()
@@ -57,9 +57,16 @@ class S3ContribCore(test_v3.RestfulTestCase):
                 'signature': base64.b64encode(sig).strip(),
                 'token': base64.b64encode(sts.encode('ascii')).strip(),
             }},
-            expected_status=http.client.OK)
+            expected_status=http.client.OK,
+            **kwargs)
         self.assertValidProjectScopedTokenResponse(resp, self.user,
                                                    forbid_token_id=True)
+
+    def test_good_response(self):
+        self._test_good_response()
+
+    def test_good_response_noauth(self):
+        self._test_good_response(noauth=True)
 
     def test_bad_request(self):
         self.post(

--- a/keystone/tests/unit/test_contrib_s3_core.py
+++ b/keystone/tests/unit/test_contrib_s3_core.py
@@ -46,27 +46,35 @@ class S3ContribCore(test_v3.RestfulTestCase):
         self.assertEqual(http.client.METHOD_NOT_ALLOWED,
                          resp.status_code)
 
-    def _test_good_response(self, **kwargs):
+    def _test_good_response(self, expected_status=http.client.OK, **kwargs):
         sts = 'string to sign'  # opaque string from swift3
         sig = hmac.new(self.cred_blob['secret'].encode('ascii'),
                        sts.encode('ascii'), hashlib.sha1).digest()
         resp = self.post(
             '/s3tokens',
-            body={'credentials': {
-                'access': self.cred_blob['access'],
-                'signature': base64.b64encode(sig).strip(),
-                'token': base64.b64encode(sts.encode('ascii')).strip(),
-            }},
-            expected_status=http.client.OK,
-            **kwargs)
-        self.assertValidProjectScopedTokenResponse(resp, self.user,
-                                                   forbid_token_id=True)
+            body={
+                'credentials': {
+                    'access': self.cred_blob['access'],
+                    'signature': base64.b64encode(sig).strip(),
+                    'token': base64.b64encode(sts.encode('ascii')).strip(),
+                }
+            },
+            expected_status=expected_status,
+            **kwargs,
+        )
+        if expected_status == http.client.OK:
+            self.assertValidProjectScopedTokenResponse(
+                resp, self.user, forbid_token_id=True
+            )
+        else:
+            self.assertValidErrorResponse(resp)
 
     def test_good_response(self):
         self._test_good_response()
 
     def test_good_response_noauth(self):
-        self._test_good_response(noauth=True)
+        # s3tokens now requires service/admin auth; unauthenticated should be denied
+        self._test_good_response(http.client.UNAUTHORIZED, noauth=True)
 
     def test_bad_request(self):
         self.post(

--- a/keystone/tests/unit/test_v3_credential.py
+++ b/keystone/tests/unit/test_v3_credential.py
@@ -79,16 +79,24 @@ class CredentialBaseTestCase(test_v3.RestfulTestCase):
 
         # Now make a request to validate the signed dummy request via the
         # ec2tokens API.  This proves the v3 ec2 credentials actually work.
-        sig_ref = {'access': access,
-                   'signature': signature,
-                   'host': 'foo',
-                   'verb': 'GET',
-                   'path': '/bar',
-                   'params': params}
+        sig_ref = {
+            'access': access,
+            'signature': signature,
+            'host': 'foo',
+            'verb': 'GET',
+            'path': '/bar',
+            'params': params,
+        }
+        PROVIDERS.assignment_api.create_system_grant_for_user(
+            self.user_id, self.role_id
+        )
+        token = self.get_system_scoped_token()
         r = self.post(
             '/ec2tokens',
             body={'ec2Credentials': sig_ref},
-            expected_status=http.client.OK)
+            expected_status=http.client.OK,
+            token=token,
+        )
         self.assertValidTokenResponse(r)
         return r.result['token']
 


### PR DESCRIPTION
Cherry-pick of https://review.opendev.org/c/openstack/keystone/+/966073, related to https://security.openstack.org/ossa/OSSA-2025-002.html

Goes along with https://github.com/sapcc/helm-charts/pull/10060