### PR TITLE
Rework `concourse_unit_test_task`

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -40,3 +40,6 @@ graphviz [test doc]
 
 # otherwise, it fails to build psycopg2, python-ldap
 build-essential [test]
+
+# otherwise, it fails to recognize pbr version
+git [test]

--- a/bindep.txt
+++ b/bindep.txt
@@ -37,3 +37,6 @@ openldap2-devel [platform:suse]
 
 # Required for sphinx graphviz image generation
 graphviz [test doc]
+
+# otherwise, it fails to build psycopg2, python-ldap
+build-essential [test]

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -16,6 +16,7 @@ pip install -U \
 cd source
 apt-get install -y \
   $(bindep -b test)
+git config --global --add safe.directory /source
 
 export KEYSTONE_IDENTITY_BACKEND=ldap
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -6,6 +6,5 @@ apt-get update && \
 apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common memcached && \
 pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0" && \
 /etc/init.d/memcached start && \
-git clone -b stable/2025.1-m3 --single-branch https://github.com/sapcc/keystone.git --depth=1 && \
-cd keystone && \
+cd source && \
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -18,6 +18,9 @@ apt-get install -y \
   $(bindep -b test)
 git config --global --add safe.directory /source
 
-export KEYSTONE_IDENTITY_BACKEND=ldap
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt
+export \
+  KEYSTONE_IDENTITY_BACKEND=ldap \
+  KEYSTONE_CLEAR_LDAP=yes \
+  ENABLE_LDAP_LIVE_TEST=true
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -23,4 +23,5 @@ export \
   KEYSTONE_IDENTITY_BACKEND=ldap \
   KEYSTONE_CLEAR_LDAP=yes \
   ENABLE_LDAP_LIVE_TEST=true
-tox -e py312
+tox -e py312 \
+  --skip-missing-interpreters=false

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,8 +1,12 @@
-export DEBIAN_FRONTEND=noninteractive && \
-export KEYSTONE_IDENTITY_BACKEND=ldap && \
-export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt && \
-apt-get update && \
-apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common && \
-pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0" && \
-cd source && \
+#!/usr/bin/env bash
+
+set -ex
+
+export DEBIAN_FRONTEND=noninteractive
+export KEYSTONE_IDENTITY_BACKEND=ldap
+export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt
+apt-get update
+apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common
+pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0"
+cd source
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -5,15 +5,18 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y \
-  python3-venv \
-  build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common
+  python3-venv
 python3 -m venv $HOME/.local/tools
 source $HOME/.local/tools/bin/activate
 pip install -U \
   pip \
+  bindep \
   tox
+
+cd source
+apt-get install -y \
+  $(bindep -b test)
 
 export KEYSTONE_IDENTITY_BACKEND=ldap
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt
-cd source
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -3,8 +3,7 @@ export KEYSTONE_IDENTITY_BACKEND=ldap && \
 export WATCHER_DISABLED=true && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt && \
 apt-get update && \
-apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common memcached && \
+apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common && \
 pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0" && \
-/etc/init.d/memcached start && \
 cd source && \
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -1,6 +1,5 @@
 export DEBIAN_FRONTEND=noninteractive && \
 export KEYSTONE_IDENTITY_BACKEND=ldap && \
-export WATCHER_DISABLED=true && \
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt && \
 apt-get update && \
 apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common && \

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -11,7 +11,7 @@ python3 -m venv $HOME/.local/tools
 source $HOME/.local/tools/bin/activate
 pip install -U \
   pip \
-  "tox<4" "six>=1.14.0" "crc<7.0.0"
+  tox
 
 export KEYSTONE_IDENTITY_BACKEND=ldap
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -3,10 +3,17 @@
 set -ex
 
 export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+  python3-venv \
+  build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common
+python3 -m venv $HOME/.local/tools
+source $HOME/.local/tools/bin/activate
+pip install -U \
+  pip \
+  "tox<4" "six>=1.14.0" "crc<7.0.0"
+
 export KEYSTONE_IDENTITY_BACKEND=ldap
 export UPPER_CONSTRAINTS_FILE=https://raw.githubusercontent.com/sapcc/requirements/stable/2025.1-m3/upper-constraints.txt
-apt-get update
-apt-get install -y build-essential python3-pip libpq-dev postgresql-client python3 python3-dev python3-distutils python3-psycopg2  git libpcre++-dev gettext libsqlite3-dev libsasl2-dev libldap2-dev libssl-dev libldap-common
-pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0"
 cd source
 tox -e py312

--- a/concourse_unit_test_task
+++ b/concourse_unit_test_task
@@ -8,4 +8,4 @@ pip3 install "tox<4" "six>=1.14.0" "crc<7.0.0" && \
 /etc/init.d/memcached start && \
 git clone -b stable/2025.1-m3 --single-branch https://github.com/sapcc/keystone.git --depth=1 && \
 cd keystone && \
-tox -e py312 -- --exclude-regex "keystone.tests.unit.test_cli.TokensDoctorTests.test_unreasonable_max_token_size_raised|keystone.tests.unit.test_config.ConfigTestCase.test_profiler_config_default"
+tox -e py312


### PR DESCRIPTION
Targets https://github.com/sapcc/keystone/pull/38

The primary motivation was https://github.com/sapcc/keystone/pull/41/commits/072411cf388d32d348f1c81e01d9fb6e367eefb3. And the rest was just revisiting and tidying up of the legacy.

Concourse executes it similar to the command below, which was also used for testing of this PR:

```console
docker run \
  --rm -v "$PWD:/source" \
  keppel.eu-de-1.cloud.sap/ccloud/loci-base@sha256:29a1941c2d3567c032cc728db3351bbd1abc63baf91396967d44edce6089ff4d \
    /bin/bash source/concourse_unit_test_task
```

which returns the following at the end

```
======
Totals
======
Ran: 5724 tests in 202.1000 sec.
 - Passed: 5007
 - Skipped: 715
 - Expected Fail: 2
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1572.0050 sec.

==============
Worker Balance
==============
 - Worker 0 (715 tests) => 0:03:13.756570
 - Worker 1 (715 tests) => 0:03:16.585094
 - Worker 2 (714 tests) => 0:03:18.076878
 - Worker 3 (716 tests) => 0:03:15.814063
 - Worker 4 (716 tests) => 0:03:18.727677
 - Worker 5 (718 tests) => 0:03:22.010053
 - Worker 6 (715 tests) => 0:03:16.453368
 - Worker 7 (715 tests) => 0:03:17.182137
  py312: OK (324.87=setup[102.91]+cmd[221.96] seconds)
  congratulations :) (325.07 seconds)
```