### PR TITLE
Re-hash sha512 hashed passwords with current hashing algorithm

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -5,3 +5,5 @@ git+https://github.com/sapcc/openstack-watcher-middleware.git#egg=watcher-middle
 git+https://github.com/funkyHat/py-radius@install_requires#egg=py-radius
 git+https://github.com/sapcc/keystone-extensions.git@stable/2025.1-m3#egg=keystone-extensions
 git+https://github.com/sapcc/openstack-rate-limit-middleware.git#egg=rate-limit-middleware
+
+passlib

--- a/keystone/common/password_hashing.py
+++ b/keystone/common/password_hashing.py
@@ -36,7 +36,10 @@ SUPPORTED_HASHERS: frozenset[type[password_hashers.PasswordHasher]] = (
     )
 )
 
-_HASHER_NAME_MAP = {hasher.name: hasher for hasher in SUPPORTED_HASHERS}
+DEPRECATED_HASHERS = frozenset([passlib.hash.sha512_crypt])
+
+_HASHER_NAME_MAP = {hasher.name: hasher for hasher in
+                    SUPPORTED_HASHERS | DEPRECATED_HASHERS}
 
 
 # NOTE(notmorgan): Build the list of prefixes. This comprehension builds
@@ -63,7 +66,7 @@ _HASHER_IDENT_MAP = {
     for module, prefix in itertools.chain(
         *[
             zip([mod] * len(ident), ident)
-            for mod, ident in _get_hash_ident(SUPPORTED_HASHERS)
+            for mod, ident in _get_hash_ident(SUPPORTED_HASHERS | DEPRECATED_HASHERS)
         ]
     )
 }
@@ -132,6 +135,11 @@ def check_password(password: str, hashed: str) -> bool:
     password_utf8 = verify_length_and_trunc_password(password)
     hasher = _get_hasher_from_ident(hashed)
     return hasher.verify(password_utf8, hashed)
+
+
+def is_deprecated_hash(hashed):
+    """Check if the password is using a deprecated hash."""
+    return _get_hasher_from_ident(hashed) in DEPRECATED_HASHERS
 
 
 def hash_user_password(user):

--- a/keystone/common/password_hashing.py
+++ b/keystone/common/password_hashing.py
@@ -18,6 +18,7 @@ import hmac
 import itertools
 
 from oslo_log import log
+import passlib.hash
 
 from keystone.common import password_hashers
 from keystone.common.password_hashers import bcrypt
@@ -38,8 +39,9 @@ SUPPORTED_HASHERS: frozenset[type[password_hashers.PasswordHasher]] = (
 
 DEPRECATED_HASHERS = frozenset([passlib.hash.sha512_crypt])
 
-_HASHER_NAME_MAP = {hasher.name: hasher for hasher in
-                    SUPPORTED_HASHERS | DEPRECATED_HASHERS}
+_HASHER_NAME_MAP = {
+    hasher.name: hasher for hasher in SUPPORTED_HASHERS | DEPRECATED_HASHERS
+}
 
 
 # NOTE(notmorgan): Build the list of prefixes. This comprehension builds
@@ -66,7 +68,9 @@ _HASHER_IDENT_MAP = {
     for module, prefix in itertools.chain(
         *[
             zip([mod] * len(ident), ident)
-            for mod, ident in _get_hash_ident(SUPPORTED_HASHERS | DEPRECATED_HASHERS)
+            for mod, ident in _get_hash_ident(
+                SUPPORTED_HASHERS | DEPRECATED_HASHERS
+            )
         ]
     )
 }

--- a/keystone/identity/backends/sql.py
+++ b/keystone/identity/backends/sql.py
@@ -76,6 +76,8 @@ class Identity(base.IdentityDriverBase):
             raise exception.UserDisabled(user_id=user_id)
         elif user_ref.password_is_expired:
             raise exception.PasswordExpired(user_id=user_id)
+        if password_hashing.is_deprecated_hash(user_ref.password):
+            self._rehash_password(user_id, password)
         # successful auth, reset failed count if present
         if user_ref.local_user.failed_auth_count:
             self._reset_failed_auth(user_id)
@@ -126,6 +128,12 @@ class Identity(base.IdentityDriverBase):
             user_ref = session.get(model.User, user_id)
             user_ref.local_user.failed_auth_count = 0
             user_ref.local_user.failed_auth_at = None
+
+    def _rehash_password(self, user_id, password):
+        with sql.session_for_write() as session:
+            user_ref = session.get(model.User, user_id)
+            user_ref.password_ref.password_hash = \
+                password_hashing.hash_password(password)
 
     # user crud
 

--- a/keystone/identity/backends/sql.py
+++ b/keystone/identity/backends/sql.py
@@ -132,8 +132,9 @@ class Identity(base.IdentityDriverBase):
     def _rehash_password(self, user_id, password):
         with sql.session_for_write() as session:
             user_ref = session.get(model.User, user_id)
-            user_ref.password_ref.password_hash = \
+            user_ref.password_ref.password_hash = (
                 password_hashing.hash_password(password)
+            )
 
     # user crud
 

--- a/keystone/tests/unit/common/test_password_hashing.py
+++ b/keystone/tests/unit/common/test_password_hashing.py
@@ -20,6 +20,8 @@ from keystone.common import password_hashing
 import keystone.conf
 from keystone.tests import unit
 
+import passlib.hash
+
 CONF = keystone.conf.CONF
 
 
@@ -90,6 +92,26 @@ class TestPasswordHashing(unit.BaseTestCase):
             )
             hashed = password_hashing.hash_password(password)
             self.assertTrue(password_hashing.check_password(password, hashed))
+
+    def test_sha512_crypt_passlib_compat(self):
+        self.config_fixture.config(strict_password_check=True)
+        # sha512_crypt is deprecated and is not supported to be set.
+        # We want to ensure that user is still able to login, thus
+        # set algo to whatever and go verify pwd
+        self.config_fixture.config(
+            group="identity", password_hash_algorithm="bcrypt"
+        )
+        self.config_fixture.config(group="identity", max_password_length="72")
+        # few iterations to test multiple random values
+        for _ in range(self.ITERATIONS):
+            password: str = "".join(  # type: ignore
+                secrets.choice(string.printable)
+                for i in range(random.randint(1, 72))
+            )
+            hashed_passlib = passlib.hash.sha512_crypt.hash(password)
+            self.assertTrue(
+                password_hashing.check_password(password, hashed_passlib)
+            )
 
 
 class TestGeneratePartialPasswordHash(unit.BaseTestCase):

--- a/keystone/tests/unit/identity/test_backend_sql.py
+++ b/keystone/tests/unit/identity/test_backend_sql.py
@@ -72,10 +72,30 @@ class UserPasswordHashingTestsNoCompat(test_backend_sql.SqlTests):
         )
 
     def test_configured_algorithm_used(self):
+        user_ref = self._get_user(self.user_foo['id'])
+        self.assertEqual(
+            passlib.hash.scrypt,
+            password_hashing._get_hasher_from_ident(user_ref.password))
+
+    def _get_user(self, user_id):
         with sql.session_for_read() as session:
             user_ref = PROVIDERS.identity_api._get_user(
-                session, self.user_foo['id']
+                session, user_id
             )
+        return user_ref
+
+    def test_deprecated_password_hash_is_updated_on_auth(self):
+        user_ref = self._get_user(self.user_foo['id'])
+        with sql.session_for_write() as session:
+            old_hash = passlib.hash.sha512_crypt.hash(
+                self.user_foo['password'])
+            user_ref.password_ref.password_hash = old_hash
+            session.add(user_ref.password_ref)
+
+        PROVIDERS.identity_api.driver.authenticate(self.user_foo['id'],
+                                                   self.user_foo['password'])
+        user_ref = self._get_user(self.user_foo['id'])
+
         self.assertEqual(
             password_hashers.scrypt.Scrypt,
             password_hashing._get_hasher_from_ident(user_ref.password),

--- a/keystone/tests/unit/identity/test_backend_sql.py
+++ b/keystone/tests/unit/identity/test_backend_sql.py
@@ -15,6 +15,7 @@ import uuid
 
 import freezegun
 from oslo_utils import timeutils
+import passlib.hash
 
 from keystone.common import password_hashers
 from keystone.common import password_hashing
@@ -74,26 +75,27 @@ class UserPasswordHashingTestsNoCompat(test_backend_sql.SqlTests):
     def test_configured_algorithm_used(self):
         user_ref = self._get_user(self.user_foo['id'])
         self.assertEqual(
-            passlib.hash.scrypt,
-            password_hashing._get_hasher_from_ident(user_ref.password))
+            password_hashers.scrypt.Scrypt,
+            password_hashing._get_hasher_from_ident(user_ref.password),
+        )
 
     def _get_user(self, user_id):
         with sql.session_for_read() as session:
-            user_ref = PROVIDERS.identity_api._get_user(
-                session, user_id
-            )
+            user_ref = PROVIDERS.identity_api._get_user(session, user_id)
         return user_ref
 
     def test_deprecated_password_hash_is_updated_on_auth(self):
         user_ref = self._get_user(self.user_foo['id'])
         with sql.session_for_write() as session:
             old_hash = passlib.hash.sha512_crypt.hash(
-                self.user_foo['password'])
+                self.user_foo['password']
+            )
             user_ref.password_ref.password_hash = old_hash
             session.add(user_ref.password_ref)
 
-        PROVIDERS.identity_api.driver.authenticate(self.user_foo['id'],
-                                                   self.user_foo['password'])
+        PROVIDERS.identity_api.driver.authenticate(
+            self.user_foo['id'], self.user_foo['password']
+        )
         user_ref = self._get_user(self.user_foo['id'])
 
         self.assertEqual(

--- a/releasenotes/notes/migrate-deprecated-password-hashes-0ffdf9eefb9ff872.yaml
+++ b/releasenotes/notes/migrate-deprecated-password-hashes-0ffdf9eefb9ff872.yaml
@@ -1,0 +1,13 @@
+---
+critical:
+  - |
+    The Epoxy release of Keystone drops support for passwords that were hashed
+    using the sha512_crypt algorithm, which was the default in Ocata and
+    earlier. As a result any passwords that are hashed with sha512_crypt will
+    not be readable in Epoxy.  This release adds the ability for the SQL
+    identity backend to update passwords that were hashed with sha512_crypt.
+    The rehashing is done when the user authenticates with the correct password,
+    so if you have user passwords that are hashed with the sha512_crypt hash
+    then users will need to authenticate at least once before Keystone is
+    upgraded by Epoxy.  Users who still have passwords hashed in sha512_crypt
+    after Keystone is upgrade to Epoxy will need to perform a password reset.


### PR DESCRIPTION
SHA512 hashing was dropped from Keystone upstream in the following changes:
* https://review.opendev.org/c/openstack/keystone/+/930223/2
* https://review.opendev.org/c/openstack/keystone/+/930225/3
* https://review.opendev.org/c/openstack/keystone/+/939778

However, the last available implementation of SHA512 - https://review.opendev.org/c/openstack/keystone/+/930223/2/keystone/common/password_hashers/sha512_crypt.py - never worked and is not correct, which could be confirmed by executing [the respective test](https://github.com/sapcc/keystone/pull/42/files#diff-306560b8b1f33485383d6c245dc1df3949b512c54c8727039c91561fac7c977fR96-R115). So it's not enough to just revert https://review.opendev.org/c/openstack/keystone/+/939778 - a proper implementation of the algorithm is needed. 

For that reason, the PR brings back `passlib` - to use its implementation of SHA512 hashing. However, it is worth noting that `passlib` was dropped from the upstream as well, which we shall also do with the next Keystone upgrade, along with the respective cherry-picked https://review.opendev.org/c/openstack/keystone/+/959279 - which brings re-hashing functionality.

With this PR In the meantime, until the next upgrade, the respective impacted users will get their password hash updated in database to the current hashing mechanism upon executing login/password authentication. There could be some users that won't log in until then, and thus won't get their hash updated - in which case it would be safe to assume that those users are no longer relevant (as they didn't log in within e.g. 6mo). Such users would have to be identified, reviewed and followed up as needed.

Upstream issue - https://bugs.launchpad.net/keystone/+bug/2133706.