### PR TITLE
Fix: Adjust the denylist to ensure proper scrubbing of token credentials.

### DIFF
--- a/keystone/wsgi/sentry_wsgi_middleware.py
+++ b/keystone/wsgi/sentry_wsgi_middleware.py
@@ -37,8 +37,7 @@ denylist = DEFAULT_DENYLIST + [
     'secret',
     'passwd',
     'credentials',
-    'x_auth_token',
-    'x_subject_token',
+    'x-subject-token',
 ]
 
 # Environment variable configuration


### PR DESCRIPTION
Updated the denylist to properly redact the x-subject-token. tested with patched image in qa-de-1
`x_auth_token` was not needed to filter this header

<img width="775" height="282" alt="image" src="https://github.com/user-attachments/assets/e41bd425-1696-4134-9f8c-254c82350043" />
