### PR TITLE
Feature: Add Prefix and Suffix Matching for Sentry Exception filtering

### DIFF
--- a/keystone/common/sentry_filter_engine.py
+++ b/keystone/common/sentry_filter_engine.py
@@ -92,6 +92,40 @@ class SentryFilterEngine:
                 )
                 return False
 
+        # exception_type_prefix
+        if 'exception_type_prefix' in rule:
+            ok = self._match_exception_type_prefix(
+                rule['exception_type_prefix'], hint
+            )
+            if ok:
+                self.debug_log(
+                    "Rule '%s': exception_type_prefix condition matched",
+                    rule_name,
+                )
+            else:
+                self.debug_log(
+                    "Rule '%s': exception_type_prefix condition did not match",
+                    rule_name,
+                )
+                return False
+
+        # exception_type_suffix
+        if 'exception_type_suffix' in rule:
+            ok = self._match_exception_type_suffix(
+                rule['exception_type_suffix'], hint
+            )
+            if ok:
+                self.debug_log(
+                    "Rule '%s': exception_type_suffix condition matched",
+                    rule_name,
+                )
+            else:
+                self.debug_log(
+                    "Rule '%s': exception_type_suffix condition did not match",
+                    rule_name,
+                )
+                return False
+
         # message_pattern
         if 'message_pattern' in rule:
             ok = self._match_message_pattern(rule['message_pattern'], hint)
@@ -179,6 +213,52 @@ class SentryFilterEngine:
 
         type_name = type(exception_instance).__name__
         return type_name == rule_type
+
+    def _match_exception_type_prefix(
+        self, prefix: str, hint: Dict[str, Any]
+    ) -> bool:
+        """Check if event exception type starts with prefix.
+
+        Args:
+            prefix: Prefix string to match
+            hint: Sentry event hint dictionary
+
+        Returns:
+            True if exception type starts with prefix
+        """
+        if 'exc_info' not in hint:
+            return False
+
+        exception_instance = hint['exc_info'][1]
+
+        if exception_instance is None:
+            return False
+
+        type_name = type(exception_instance).__name__
+        return type_name.startswith(prefix)
+
+    def _match_exception_type_suffix(
+        self, suffix: str, hint: Dict[str, Any]
+    ) -> bool:
+        """Check if event exception type ends with suffix.
+
+        Args:
+            suffix: Suffix string to match
+            hint: Sentry event hint dictionary
+
+        Returns:
+            True if exception type ends with suffix
+        """
+        if 'exc_info' not in hint:
+            return False
+
+        exception_instance = hint['exc_info'][1]
+
+        if exception_instance is None:
+            return False
+
+        type_name = type(exception_instance).__name__
+        return type_name.endswith(suffix)
 
     def _match_message_pattern(
         self, pattern: str, hint: Dict[str, Any]

--- a/keystone/common/sentry_rule_loader.py
+++ b/keystone/common/sentry_rule_loader.py
@@ -118,19 +118,40 @@ def _validate_rule(rule: Dict[str, Any], rule_name: str) -> Dict[str, Any]:
     # At least one filtering condition must be specified
     has_condition = any(
         field in rule
-        for field in ['exception_type', 'message_pattern', 'message_contains']
+        for field in [
+            'exception_type',
+            'exception_type_prefix',
+            'exception_type_suffix',
+            'message_pattern',
+            'message_contains',
+        ]
     )
 
     if not has_condition:
         raise RuleValidationError(
             "Rule must specify at least one condition: "
-            "'exception_type', 'message_pattern', or 'message_contains'"
+            "'exception_type', 'exception_type_prefix', 'exception_type_suffix', "
+            "'message_pattern', or 'message_contains'"
         )
 
     # Validate exception_type
     if 'exception_type' in rule:
         if not isinstance(rule['exception_type'], str):
             raise RuleValidationError("'exception_type' must be a string")
+
+    # Validate exception_type_prefix
+    if 'exception_type_prefix' in rule:
+        if not isinstance(rule['exception_type_prefix'], str):
+            raise RuleValidationError(
+                "'exception_type_prefix' must be a string"
+            )
+
+    # Validate exception_type_suffix
+    if 'exception_type_suffix' in rule:
+        if not isinstance(rule['exception_type_suffix'], str):
+            raise RuleValidationError(
+                "'exception_type_suffix' must be a string"
+            )
 
     # Validate message_pattern (regex)
     if 'message_pattern' in rule:

--- a/keystone/tests/unit/common/test_sentry_filter_engine.py
+++ b/keystone/tests/unit/common/test_sentry_filter_engine.py
@@ -217,3 +217,63 @@ class SentryFilterEngineTestCase(unit.BaseTestCase):
         no_exception_hint = {'other_field': 'value'}
         result = engine.should_filter_event(no_exception_hint)
         self.assertFalse(result)
+
+    def test_exception_type_prefix_matching(self):
+        """Test exception type prefix matching."""
+        rules = [{'name': 'test_rule', 'exception_type_prefix': 'LDAP'}]
+        engine = SentryFilterEngine(rules)
+
+        # Matching prefix should be filtered
+        matching_hint1 = self._create_hint_with_exception('LDAPError', 'test')
+        result = engine.should_filter_event(matching_hint1)
+        self.assertTrue(result)
+
+        matching_hint2 = self._create_hint_with_exception(
+            'LDAPConnectionError', 'test'
+        )
+        result = engine.should_filter_event(matching_hint2)
+        self.assertTrue(result)
+
+        matching_hint3 = self._create_hint_with_exception(
+            'LDAPInvalidCredentialsError', 'test'
+        )
+        result = engine.should_filter_event(matching_hint3)
+        self.assertTrue(result)
+
+        # Non-matching prefix should not be filtered
+        non_matching_hint = self._create_hint_with_exception(
+            'DatabaseError', 'test'
+        )
+        result = engine.should_filter_event(non_matching_hint)
+        self.assertFalse(result)
+
+    def test_exception_type_suffix_matching(self):
+        """Test exception type suffix matching."""
+        rules = [{'name': 'test_rule', 'exception_type_suffix': 'NotFound'}]
+        engine = SentryFilterEngine(rules)
+
+        # Matching suffix should be filtered
+        matching_hint1 = self._create_hint_with_exception(
+            'TokenNotFound', 'test'
+        )
+        result = engine.should_filter_event(matching_hint1)
+        self.assertTrue(result)
+
+        matching_hint2 = self._create_hint_with_exception(
+            'UserNotFound', 'test'
+        )
+        result = engine.should_filter_event(matching_hint2)
+        self.assertTrue(result)
+
+        matching_hint3 = self._create_hint_with_exception(
+            'ProjectNotFound', 'test'
+        )
+        result = engine.should_filter_event(matching_hint3)
+        self.assertTrue(result)
+
+        # Non-matching suffix should not be filtered
+        non_matching_hint = self._create_hint_with_exception(
+            'ValidationError', 'test'
+        )
+        result = engine.should_filter_event(non_matching_hint)
+        self.assertFalse(result)

--- a/keystone/tests/unit/common/test_sentry_rule_loader.py
+++ b/keystone/tests/unit/common/test_sentry_rule_loader.py
@@ -406,3 +406,47 @@ class SentryRuleLoaderTestCase(unit.BaseTestCase):
         self.assertRaises(
             RuleValidationError, load_rules_from_file, config_file
         )
+
+    def test_exception_type_prefix_valid(self):
+        """Test validation succeeds with exception_type_prefix."""
+        config_data = {
+            'rules': {'test_rule': {'exception_type_prefix': 'LDAP'}}
+        }
+        config_file = self._create_temp_config(config_data)
+
+        # Should not raise any exceptions
+        rules = load_rules_from_file(config_file)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0]['name'], 'test_rule')
+        self.assertEqual(rules[0]['exception_type_prefix'], 'LDAP')
+
+    def test_exception_type_prefix_not_string(self):
+        """Test validation fails when exception_type_prefix is not a string."""
+        config_data = {'rules': {'test_rule': {'exception_type_prefix': 123}}}
+        config_file = self._create_temp_config(config_data)
+
+        self.assertRaises(
+            RuleValidationError, load_rules_from_file, config_file
+        )
+
+    def test_exception_type_suffix_valid(self):
+        """Test validation succeeds with exception_type_suffix."""
+        config_data = {
+            'rules': {'test_rule': {'exception_type_suffix': 'Error'}}
+        }
+        config_file = self._create_temp_config(config_data)
+
+        # Should not raise any exceptions
+        rules = load_rules_from_file(config_file)
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0]['name'], 'test_rule')
+        self.assertEqual(rules[0]['exception_type_suffix'], 'Error')
+
+    def test_exception_type_suffix_not_string(self):
+        """Test validation fails when exception_type_suffix is not a string."""
+        config_data = {'rules': {'test_rule': {'exception_type_suffix': 123}}}
+        config_file = self._create_temp_config(config_data)
+
+        self.assertRaises(
+            RuleValidationError, load_rules_from_file, config_file
+        )

--- a/sentry_filters_example.yaml
+++ b/sentry_filters_example.yaml
@@ -2,7 +2,9 @@
 # This file demonstrates various filtering rules for Keystone Sentry integration
 #
 # Rule Types:
-# - exception_type: Filter by exception class name
+# - exception_type: Filter by exact exception class name
+# - exception_type_prefix: Filter by exception class name prefix (e.g., "LDAP" matches LDAPError, LDAPConnectionError, etc.)
+# - exception_type_suffix: Filter by exception class name suffix (e.g., "Error" matches ValueError, TypeError, etc.)
 # - message_pattern: Filter by regex pattern in exception message
 # - message_contains: Filter by simple string in exception message
 # - rate_limit: Limit occurrences of specific exceptions over a time window
@@ -73,6 +75,25 @@ rules:
     rate_limit:
       max_occurrences: 1
       time_window: 3600  # 1 hour - only log once per hour in case tests run in prod
+
+  # Prefix-based filtering - filter all LDAP-related exceptions
+  filter_all_ldap_errors:
+    exception_type_prefix: "LDAP"
+    rate_limit:
+      max_occurrences: 10
+      time_window: 300  # 5 minutes
+
+  # Suffix-based filtering - filter all exceptions ending with "NotFound"
+  filter_all_not_found_errors:
+    exception_type_suffix: "NotFound"
+
+  # Suffix-based filtering with rate limiting - filter common error types
+  rate_limit_generic_errors:
+    exception_type_suffix: "Error"
+    message_contains: "temporary"
+    rate_limit:
+      max_occurrences: 5
+      time_window: 600  # 10 minutes
 
 # Configuration guidelines:
 #


### PR DESCRIPTION
Because we do have a lot of ...NotFound Exceptions i created these additional rules to reduce the total needed rules to filter all exceptions from a certain type.

<img width="430" height="1243" alt="image" src="https://github.com/user-attachments/assets/ffd4cb8a-a477-4301-a4a2-850e55e46f7e" />
