### PR TITLE
Replace deprecated usage of pkg_resources in tests

### DIFF
--- a/keystone/tests/unit/test_backend_ldap.py
+++ b/keystone/tests/unit/test_backend_ldap.py
@@ -19,9 +19,9 @@ from unittest import mock
 import uuid
 
 import fixtures
+from importlib.metadata import entry_points
 import ldap
 from oslo_log import versionutils
-import pkg_resources  # type: ignore
 from testtools import matchers
 
 from keystone.common import cache
@@ -57,8 +57,9 @@ def _assert_backends(testcase, **kwargs):
         return observed_backend.__class__
 
     def _get_entrypoint_cls(subsystem, name):
-        entrypoint = entrypoint_map['keystone.' + subsystem][name]
-        return entrypoint.resolve()
+        (ep,) = entry_points(group=f"keystone.{subsystem}", name=name)
+        if ep:
+            return ep.load()
 
     def _load_domain_specific_configs(manager):
         if (
@@ -81,10 +82,6 @@ def _assert_backends(testcase, **kwargs):
             'observed_cls': observed_cls,
             'subsystem': subsystem,
         }
-
-    env = pkg_resources.Environment()
-    keystone_dist = env['keystone'][0]
-    entrypoint_map = pkg_resources.get_entry_map(keystone_dist)
 
     for subsystem, entrypoint_name in kwargs.items():
         if isinstance(entrypoint_name, str):


### PR DESCRIPTION
pkg_resources should not be used since 3.12. We still use it in unittests and it cause mypy to fail. Replace it with importlib

NOTE(bbobrov): This patch breaks python 3.9 compatibility but we do not care.

(cherry picked from commit d57db0fb3cd4a21b4a1b64952f5ffe52db1b3f6e)
Change-Id: I6b2536b8ab820daae435feecf44f7ae83ab1b23e