### PR TITLE
Fix CADF audit event field naming and action taxonomy

### DIFF
--- a/keystone/auth/plugins/core.py
+++ b/keystone/auth/plugins/core.py
@@ -19,6 +19,7 @@ from pycadf import resource
 
 from keystone.common import driver_hints
 from keystone.common import provider_api
+from keystone.common import utils
 import keystone.conf
 from keystone import exception
 from keystone import notifications
@@ -187,13 +188,15 @@ class BaseUserInfo(provider_api.ProviderAPIMixin):
             audit_initiator = notifications.build_audit_initiator()
             # build an appropriate audit initiator with relevant information
             # for the failed request. This will catch invalid user_name and
-            # invalid user_id.
+            # invalid user_id. Use CADF-compliant fields (id, name) instead
+            # of ad-hoc attributes (user_id, user_name).
             if user_name:
-                audit_initiator.user_name = user_name
+                audit_initiator.name = user_name
             else:
-                audit_initiator.user_id = user_id
+                audit_initiator.id = utils.resource_uuid(user_id)
             audit_initiator.domain_id = domain_ref.get('id')
-            audit_initiator.domain_name = domain_ref.get('name')
+            if domain_ref.get('name'):
+                audit_initiator.domain = domain_ref.get('name')
             notifications._send_audit_notification(
                 action=_NOTIFY_OP,
                 initiator=audit_initiator,

--- a/keystone/notifications.py
+++ b/keystone/notifications.py
@@ -58,6 +58,16 @@ ACTIONS = _ACTIONS(
 )
 """The actions on resources."""
 
+# CADF action taxonomy uses the imperative form with '/' separator
+# e.g., 'create/user' instead of 'created.user'
+_CADF_ACTION_MAP = {
+    'created': 'create',
+    'deleted': 'delete',
+    'disabled': 'disable',
+    'updated': 'update',
+    'internal': 'internal',
+}
+
 CADF_TYPE_MAP = {
     'group': taxonomy.SECURITY_GROUP,
     'project': taxonomy.SECURITY_PROJECT,
@@ -106,7 +116,6 @@ def build_audit_initiator():
     oslo_context = flask.request.environ.get(context.REQUEST_CONTEXT_ENV)
     if oslo_context.user_id:
         initiator.id = utils.resource_uuid(oslo_context.user_id)
-        initiator.user_id = oslo_context.user_id
 
     if oslo_context.project_id:
         initiator.project_id = oslo_context.project_id
@@ -573,7 +582,9 @@ def _create_cadf_payload(
     target = resource.Resource(typeURI=target_uri, id=resource_id)
 
     audit_kwargs = {'resource_info': resource_id}
-    cadf_action = f'{operation}.{resource_type}'
+    cadf_action = (
+        f'{_CADF_ACTION_MAP.get(operation, operation)}/{resource_type}'
+    )
     event_type = f'{SERVICE}.{resource_type}.{operation}'
 
     _send_audit_notification(
@@ -675,7 +686,6 @@ def _get_request_audit_info(context, user_id=None):
     initiator = resource.Resource(typeURI=taxonomy.ACCOUNT_USER, host=host)
 
     if user_id:
-        initiator.user_id = user_id
         initiator.id = utils.resource_uuid(user_id)
         initiator = _add_username_to_initiator(initiator)
 
@@ -713,9 +723,8 @@ class CadfNotificationWrapper:
             """Will always send a notification."""
             target = resource.Resource(typeURI=taxonomy.ACCOUNT_USER)
             initiator = build_audit_initiator()
-            initiator.user_id = user_id
-            initiator = _add_username_to_initiator(initiator)
             initiator.id = utils.resource_uuid(user_id)
+            initiator = _add_username_to_initiator(initiator)
             try:
                 result = f(wrapped_self, user_id, *args, **kwargs)
             except (exception.AccountLocked, exception.PasswordExpired) as ex:
@@ -809,7 +818,7 @@ class CadfRoleAssignmentNotificationWrapper:
     ROLE_ASSIGNMENT = 'role_assignment'
 
     def __init__(self, operation):
-        self.action = f'{operation}.{self.ROLE_ASSIGNMENT}'
+        self.action = f'{_CADF_ACTION_MAP.get(operation, operation)}/{self.ROLE_ASSIGNMENT}'
         self.event_type = f'{SERVICE}.{self.ROLE_ASSIGNMENT}.{operation}'
 
     def __call__(self, f):
@@ -865,19 +874,40 @@ class CadfRoleAssignmentNotificationWrapper:
             initiator = call_args.get('initiator', None)
             target = resource.Resource(typeURI=taxonomy.ACCOUNT_USER)
 
-            audit_kwargs = {}
+            # Set scope on the target resource (CADF-compliant)
             if call_args['project_id']:
-                audit_kwargs['project'] = call_args['project_id']
+                target.project_id = call_args['project_id']
             elif call_args['domain_id']:
-                audit_kwargs['domain'] = call_args['domain_id']
+                target.domain_id = call_args['domain_id']
 
+            # Set target.id to the actor (user or group being assigned)
             if call_args['user_id']:
-                audit_kwargs['user'] = call_args['user_id']
+                target.id = call_args['user_id']
             elif call_args['group_id']:
-                audit_kwargs['group'] = call_args['group_id']
+                target.id = call_args['group_id']
 
-            audit_kwargs['inherited_to_projects'] = inherited
-            audit_kwargs['role'] = role_id
+            # Build CADF attachments for role assignment metadata
+            # Uses CADF attachment typeURIs per the DMTF CADF spec
+            audit_attachments = [
+                attachment.Attachment(
+                    typeURI='/data/security/role',
+                    content=role_id,
+                    name='role_id',
+                ),
+                attachment.Attachment(
+                    typeURI='xs:boolean',
+                    content=str(inherited).lower(),
+                    name='inherited_to_projects',
+                ),
+            ]
+            if call_args['group_id']:
+                audit_attachments.append(
+                    attachment.Attachment(
+                        typeURI='/data/security/group',
+                        content=call_args['group_id'],
+                        name='group_id',
+                    )
+                )
 
             try:
                 result = f(wrapped_self, role_id, *args, **kwargs)
@@ -888,7 +918,7 @@ class CadfRoleAssignmentNotificationWrapper:
                     taxonomy.OUTCOME_FAILURE,
                     target,
                     self.event_type,
-                    **audit_kwargs,
+                    attachments=audit_attachments,
                 )
                 raise
             else:
@@ -898,7 +928,7 @@ class CadfRoleAssignmentNotificationWrapper:
                     taxonomy.OUTCOME_SUCCESS,
                     target,
                     self.event_type,
-                    **audit_kwargs,
+                    attachments=audit_attachments,
                 )
                 return result
 
@@ -1054,14 +1084,16 @@ def _check_notification_opt_out(event_type, outcome):
 
 
 def _add_username_to_initiator(initiator):
-    """Add the username to the initiator if missing."""
-    if hasattr(initiator, 'username'):
+    """Add the username to the initiator using the CADF-compliant 'name' field."""
+    if initiator is None:
+        return initiator
+    if 'name' in initiator.as_dict():
         return initiator
     try:
-        user_ref = PROVIDERS.identity_api.get_user(initiator.user_id)
-        initiator.username = user_ref['name']
+        user_ref = PROVIDERS.identity_api.get_user(initiator.id)
+        initiator.name = user_ref['name']
     except (exception.UserNotFound, AttributeError):
-        # Either user not found or no user_id, move along
+        # Either user not found or no id, move along
         pass
 
     return initiator

--- a/keystone/notifications.py
+++ b/keystone/notifications.py
@@ -554,8 +554,10 @@ def _create_cadf_payload(
     top level value for the ``resource_info`` key. Lastly, the ``operation`` is
     used to create the CADF ``action``, and the ``event_type`` name.
 
-    As per the CADF specification, the ``action`` must start with create,
-    update, delete, etc... i.e.: created.user or deleted.role
+    As per the CADF specification, the ``action`` uses the imperative
+    taxonomy with a ``/`` separator, i.e.: ``create/user`` or
+    ``delete/role``. The mapping from oslo operation verbs to CADF action
+    verbs is defined in ``_CADF_ACTION_MAP``.
 
     However the ``event_type`` is an OpenStack-ism that is typically of the
     form project.resource.operation. i.e.: identity.project.updated
@@ -805,7 +807,7 @@ class CadfRoleAssignmentNotificationWrapper:
     This function is only used for role assignment events. Its ``action`` and
     ``event_type`` are dictated below.
 
-    - action: ``created.role_assignment`` or ``deleted.role_assignment``
+    - action: ``create/role_assignment`` or ``delete/role_assignment``
     - event_type: ``identity.role_assignment.created`` or
         ``identity.role_assignment.deleted``
 
@@ -872,7 +874,16 @@ class CadfRoleAssignmentNotificationWrapper:
             )
             inherited = call_args['inherited_to_projects']
             initiator = call_args.get('initiator', None)
-            target = resource.Resource(typeURI=taxonomy.ACCOUNT_USER)
+
+            # Pick a CADF target typeURI that matches the actor kind.
+            # pycadf has no ACCOUNT_GROUP constant; use SECURITY_GROUP
+            # ('data/security/group') for group assignments so the
+            # target resource type is consistent with target.id.
+            if call_args['group_id']:
+                target_type_uri = taxonomy.SECURITY_GROUP
+            else:
+                target_type_uri = taxonomy.ACCOUNT_USER
+            target = resource.Resource(typeURI=target_type_uri)
 
             # Set scope on the target resource (CADF-compliant)
             if call_args['project_id']:

--- a/keystone/tests/unit/common/test_notifications.py
+++ b/keystone/tests/unit/common/test_notifications.py
@@ -45,6 +45,9 @@ UPDATED_OPERATION = notifications.ACTIONS.updated
 DELETED_OPERATION = notifications.ACTIONS.deleted
 DISABLED_OPERATION = notifications.ACTIONS.disabled
 
+# CADF action taxonomy uses imperative form (create, delete, update, disable)
+CADF_ACTION_MAP = notifications._CADF_ACTION_MAP
+
 
 class ArbitraryException(Exception):
     pass
@@ -220,7 +223,7 @@ class NotificationsTestCase(unit.BaseTestCase):
         """
         resource_type = EXP_RESOURCE_TYPE
 
-        action = CREATED_OPERATION + '.' + resource_type
+        action = CADF_ACTION_MAP[CREATED_OPERATION] + '/' + resource_type
         initiator = mock
         target = mock
         outcome = 'success'
@@ -241,7 +244,7 @@ class NotificationsTestCase(unit.BaseTestCase):
         """Test that authenticate events are successfully opted out."""
         resource_type = EXP_RESOURCE_TYPE
 
-        action = CREATED_OPERATION + '.' + resource_type
+        action = CADF_ACTION_MAP[CREATED_OPERATION] + '/' + resource_type
         initiator = mock
         target = mock
         outcome = 'success'
@@ -381,7 +384,12 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
         payload = audit['payload']
         if 'resource_info' in payload:
             self.assertEqual(resource_id, payload['resource_info'])
-        action = '.'.join(filter(None, [operation, resource_type]))
+        action = '/'.join(
+            filter(
+                None,
+                [CADF_ACTION_MAP.get(operation, operation), resource_type],
+            )
+        )
         self.assertEqual(action, payload['action'])
         self.assertEqual(target_uri, payload['target']['typeURI'])
         if resource_id:
@@ -416,7 +424,7 @@ class BaseNotificationTest(test_v3.RestfulTestCase):
         self.assertEqual(self.project_id, payload['initiator']['project_id'])
         self.assertEqual(typeURI, payload['target']['typeURI'])
         self.assertIn('request_id', payload['initiator'])
-        action = f'{operation}.{resource_type}'
+        action = f'{CADF_ACTION_MAP.get(operation, operation)}/{resource_type}'
         self.assertEqual(action, payload['action'])
 
     def _assert_notify_not_sent(
@@ -1500,6 +1508,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
             target,
             event_type,
             reason=None,
+            attachments=None,
             **kwargs,
         ):
             service_security = cadftaxonomy.SERVICE_SECURITY
@@ -1514,12 +1523,17 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
                 observer=cadfresource.Resource(typeURI=service_security),
             )
 
+            if attachments:
+                for attach in attachments:
+                    event.add_attachment(attach)
+
             for key, value in kwargs.items():
                 setattr(event, key, value)
 
             note = {
                 'action': action,
                 'initiator': initiator,
+                'target': target,
                 'event': event,
                 'event_type': event_type,
                 'send_notification_called': True,
@@ -1558,8 +1572,11 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
     ):
         """Assert that the CADF event is valid.
 
-        In the case of role assignments, the event will have extra data,
-        specifically, the role, target, actor, and if the role is inherited.
+        In the case of role assignments, the event will have extra data
+        stored in CADF-compliant locations:
+        - Scope (project/domain) and actor (user/group) are on the target
+          resource object
+        - Role and inherited_to_projects are in CADF attachments
 
         An example event, as a dictionary is seen below:
             {
@@ -1568,39 +1585,60 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
                     'typeURI': 'service/security/account/user',
                     'host': {'address': 'localhost'},
                     'id': 'openstack:0a90d95d-582c-4efb-9cbc-e2ca7ca9c341',
-                    'username': u'admin'
+                    'name': u'admin'
                 },
                 'target': {
                     'typeURI': 'service/security/account/user',
-                    'id': 'openstack:d48ea485-ef70-4f65-8d2b-01aa9d7ec12d'
+                    'id': 'openstack:d48ea485-ef70-4f65-8d2b-01aa9d7ec12d',
+                    'project_id': '...',
                 },
                 'observer': {
                     'typeURI': 'service/security',
                     'id': 'openstack:d51dd870-d929-4aba-8d75-dcd7555a0c95'
                 },
+                'attachments': [
+                    {'name': 'role_id',
+                     'typeURI': '/data/security/role',
+                     'content': '...'},
+                    {'name': 'inherited_to_projects',
+                     'typeURI': 'xs:boolean',
+                     'content': 'False'}
+                ],
                 'eventType': 'activity',
                 'eventTime': '2014-08-21T21:04:56.204536+0000',
-                'role': u'0e6b990380154a2599ce6b6e91548a68',
-                'domain': u'24bdcff1aab8474895dbaac509793de1',
-                'inherited_to_projects': False,
-                'group': u'c1e22dc67cbd469ea0e33bf428fe597a',
-                'action': 'created.role_assignment',
+                'action': 'create/role_assignment',
                 'outcome': 'success',
                 'id': 'openstack:782689dd-f428-4f13-99c7-5c70f94a5ac1'
             }
         """
         note = self._notifications[-1]
+        target = note['target']
         event = note['event']
+
+        # Check scope on target resource
         if project:
-            self.assertEqual(project, event.project)
+            self.assertEqual(project, target.project_id)
         if domain:
-            self.assertEqual(domain, event.domain)
+            self.assertEqual(domain, target.domain_id)
+
+        # Check actor on target resource (target.id holds user or group)
         if group:
-            self.assertEqual(group, event.group)
+            self.assertEqual(group, target.id)
         elif user:
-            self.assertEqual(user, event.user)
-        self.assertEqual(role_id, event.role)
-        self.assertEqual(inherit, event.inherited_to_projects)
+            self.assertEqual(user, target.id)
+
+        # Check role and inherited in attachments
+        event_dict = event.as_dict()
+        attachments = event_dict.get('attachments', [])
+        attachment_map = {a['name']: a['content'] for a in attachments}
+        self.assertEqual(role_id, attachment_map['role_id'])
+        self.assertEqual(
+            str(inherit).lower(), attachment_map['inherited_to_projects']
+        )
+
+        # Check group attachment exists when group_id is set
+        if group:
+            self.assertEqual(group, attachment_map['group_id'])
 
     def test_initiator_id_always_matches_user_id(self):
         # Clear notifications
@@ -1612,7 +1650,6 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
         note = self._notifications.pop()
         initiator = note['initiator']
         self.assertEqual(self.user_id, initiator.id)
-        self.assertEqual(self.user_id, initiator.user_id)
 
     def test_initiator_always_contains_username(self):
         # Clear notifications
@@ -1623,7 +1660,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
         self.assertEqual(len(self._notifications), 1)
         note = self._notifications.pop()
         initiator = note['initiator']
-        self.assertEqual(self.user['name'], initiator.username)
+        self.assertEqual(self.user['name'], initiator.name)
 
     def test_v3_authenticate_user_name_and_domain_id(self):
         user_id = self.user_id
@@ -1659,7 +1696,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
 
         # Confirm user-name specific event was emitted.
         self.assertEqual(self.ACTION, note['action'])
-        self.assertEqual(user_id, initiator.user_id)
+        self.assertEqual(user_id, initiator.id)
         self.assertTrue(note['send_notification_called'])
         self.assertEqual(cadftaxonomy.OUTCOME_FAILURE, note['event'].outcome)
         self.assertEqual(self.LOCAL_HOST, initiator.host.address)
@@ -1679,7 +1716,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
 
         # Confirm user-name specific event was emitted.
         self.assertEqual(self.ACTION, note['action'])
-        self.assertEqual(user_name, initiator.user_name)
+        self.assertEqual(user_name, initiator.name)
         self.assertEqual(domain_id, initiator.domain_id)
         self.assertTrue(note['send_notification_called'])
         self.assertEqual(cadftaxonomy.OUTCOME_FAILURE, note['event'].outcome)
@@ -1700,12 +1737,12 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
         self, url, role, project=None, domain=None, user=None, group=None
     ):
         self.put(url)
-        action = f"{CREATED_OPERATION}.{self.ROLE_ASSIGNMENT}"
+        action = f"{CADF_ACTION_MAP[CREATED_OPERATION]}/{self.ROLE_ASSIGNMENT}"
         event_type = f'{notifications.SERVICE}.{self.ROLE_ASSIGNMENT}.{CREATED_OPERATION}'
         self._assert_last_note(action, self.user_id, event_type)
         self._assert_event(role, project, domain, user, group)
         self.delete(url)
-        action = f"{DELETED_OPERATION}.{self.ROLE_ASSIGNMENT}"
+        action = f"{CADF_ACTION_MAP[DELETED_OPERATION]}/{self.ROLE_ASSIGNMENT}"
         event_type = f'{notifications.SERVICE}.{self.ROLE_ASSIGNMENT}.{DELETED_OPERATION}'
         self._assert_last_note(action, self.user_id, event_type)
         self._assert_event(role, project, domain, user, None)
@@ -1743,7 +1780,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
 
         self.assertTrue(self._notifications)
         note = self._notifications[-1]
-        self.assertEqual('created.role_assignment', note['action'])
+        self.assertEqual('create/role_assignment', note['action'])
         self.assertTrue(note['send_notification_called'])
 
         self._assert_event(self.role_id, project=project_id, user=self.user_id)
@@ -1758,7 +1795,7 @@ class CadfNotificationsWrapperTestCase(test_v3.RestfulTestCase):
 
         self.assertTrue(self._notifications)
         note = self._notifications[-1]
-        self.assertEqual('deleted.role_assignment', note['action'])
+        self.assertEqual('delete/role_assignment', note['action'])
         self.assertTrue(note['send_notification_called'])
 
         self._assert_event(
@@ -1893,7 +1930,7 @@ class CADFNotificationsDataTestCase(test_v3.RestfulTestCase):
             ref['type'] = 'identity'
             PROVIDERS.catalog_api.create_service(ref['id'], ref.copy())
 
-        action = CREATED_OPERATION + '.' + resource_type
+        action = CADF_ACTION_MAP[CREATED_OPERATION] + '/' + resource_type
         initiator = notifications._get_request_audit_info(self.user_id)
         target = cadfresource.Resource(typeURI=cadftaxonomy.ACCOUNT_USER)
         outcome = 'success'


### PR DESCRIPTION
## Summary

Keystone emits CADF audit events with non-standard field names and action formats that diverge from the DMTF CADF specification (DSP0262). This PR corrects them to be compliant.

## Changes

| Before (ad-hoc) | After (CADF-compliant) | Spec reference |
|---|---|---|
| `initiator.user_id` | `initiator.id` | CADF Resource.id |
| `initiator.username` / `user_name` | `initiator.name` | CADF Resource.name |
| `initiator.domain_name` | `initiator.domain` | CADF Resource.domain |
| `action: "created.user"` | `action: "create/user"` | CADF action taxonomy (imperative form, `/` separator) |
| Role assignment as top-level kwargs | `target.project_id` / `target.domain_id` + CADF attachments | CADF Resource fields + Attachment spec |

The oslo `event_type` format (`identity.user.created`) is **unchanged**.

## Why

1. **CADF compliance**: The [DMTF CADF spec](https://www.dmtf.org/standards/cadf) defines `Resource.id`, `Resource.name`, and `Resource.domain` as the standard fields. Ad-hoc attributes like `user_id` and `username` are non-standard extensions that downstream consumers must special-case.

2. **Consistency with other OpenStack services**: The [openstack-audit-middleware](https://github.com/sapcc/openstack-audit-middleware) already emits actions using pycadf taxonomy constants (`taxonomy.ACTION_CREATE = 'create'`, etc.) with `/` separators. Keystone was the only service using past-tense dotted format (`created.user`).

3. **Spec alignment with SAP CC CADF schema**: The [go-api-declarations CADF Resource struct](https://github.com/sapcc/go-api-declarations/blob/main/cadf/event.go) expects `ID`, `Name`, `Domain`, `DomainID`, `ProjectID` — matching what this PR now emits.

## End-user impact

Audit event consumers that parse the CADF `action` field already see `create/user` instead of `created.user`. The structured data (who did what to whom) is identical. Now instead of it existing in a transform, it exists where it belongs in Keystone

## Test plan

- [x] Unit tests updated to assert new action format and field names
- [ ] CI passes (`tox -e py3`)
- [ ] Deploy to QA and verify audit events contain correct CADF fields