### PR TITLE
Fix/ldap pagination

### DIFF
--- a/keystone/identity/backends/ldap/common.py
+++ b/keystone/identity/backends/ldap/common.py
@@ -1151,8 +1151,7 @@ class KeystoneLDAPHandler(LDAPHandler):
         if attrlist is not None:
             attrlist = [attr for attr in attrlist if attr is not None]
         LOG.debug(
-            'LDAP search: base=%s scope=%s filterstr=%s '
-            'attrs=%s attrsonly=%s',
+            'LDAP search: base=%s scope=%s filterstr=%s attrs=%s attrsonly=%s',
             base,
             scope,
             filterstr,
@@ -1215,7 +1214,11 @@ class KeystoneLDAPHandler(LDAPHandler):
             sizelimit,
         )
 
-    def _paged_search_s(self, base, scope, filterstr, attrlist=None):
+    def _paged_search_s(
+        self, base, scope, filterstr, attrlist=None, sizelimit=0
+    ):
+        if attrlist is not None:
+            attrlist = [attr for attr in attrlist if attr is not None]
         res = []
         use_old_paging_api = False
         # The API for the simple paged results control changed between
@@ -1242,9 +1245,20 @@ class KeystoneLDAPHandler(LDAPHandler):
         while True:
             # Request to the ldap server a page with 'page_size' entries
             rtype, rdata, rmsgid, serverctrls = self.conn.result3(message)
-            # Receive the data
-            res.extend(rdata)
-            pctrls = [c for c in serverctrls if c.controlType == page_ctrl_oid]
+            res.extend(convert_ldap_result(rdata))
+
+            # Handle case where serverctrls is None (e.g., in fake LDAP)
+            pctrls = [
+                c
+                for c in (serverctrls or [])
+                if c.controlType == page_ctrl_oid
+            ]
+
+            # Check if we've collected enough results
+            if sizelimit and len(res) >= sizelimit:
+                res = res[:sizelimit]
+                break
+
             if pctrls:
                 # LDAP server supports pagination
                 if use_old_paging_api:
@@ -1738,7 +1752,7 @@ class BaseLdap:
         if not attr:
             attr_name = f'{self.options_name}_{self.attribute_options_names[ldap_attr_name]}_attribute'
             raise ValueError(
-                f'"{attr}" is not a valid value for' f' "{attr_name}"'
+                f'"{attr}" is not a valid value for "{attr_name}"'
             )
 
         # consider attr = "cn" and
@@ -1772,9 +1786,7 @@ class BaseLdap:
 
     def _ldap_get(self, object_id, ldap_filter=None):
         query = (
-            '(&({id_attr}={id})'
-            '{filter}'
-            '(objectClass={object_class}))'.format(
+            '(&({id_attr}={id}){filter}(objectClass={object_class}))'.format(
                 id_attr=self.id_attr,
                 id=ldap.filter.escape_filter_chars(str(object_id)),
                 filter=ldap_filter or self.ldap_filter or '',
@@ -1808,20 +1820,6 @@ class BaseLdap:
         except IndexError:
             return None
 
-    def _ldap_get_limited(self, base, scope, filterstr, attrlist, sizelimit):
-        with self.get_connection() as conn:
-            try:
-                control = ldap.controls.libldap.SimplePagedResultsControl(
-                    criticality=True, size=sizelimit, cookie=''
-                )
-                msgid = conn.search_ext(
-                    base, scope, filterstr, attrlist, serverctrls=[control]
-                )
-                rdata = conn.result3(msgid)
-                return rdata
-            except ldap.NO_SUCH_OBJECT:
-                return []
-
     @driver_hints.truncated
     def _ldap_get_all(self, hints, ldap_filter=None):
         query = '(&{}(objectClass={})({}=*))'.format(
@@ -1829,29 +1827,35 @@ class BaseLdap:
             self.object_class,
             self.id_attr,
         )
-        sizelimit = 0
-        attrs = list(
-            set(
-                [self.id_attr]
-                + list(self.attribute_mapping.values())
-                + list(self.extra_attr_mapping.keys())
-            )
-        )
-        # ccloud: only limit if all filters have been satisfied and the
-        # contoller does not need to filter
-        if hints.limit and not len(hints.filters):
-            sizelimit = hints.limit['limit']
-            res = self._ldap_get_limited(
-                self.tree_dn, self.LDAP_SCOPE, query, attrs, sizelimit
-            )
-        else:
-            with self.get_connection() as conn:
-                try:
+        candidates = [
+            self.id_attr,
+            *self.attribute_mapping.values(),
+            *self.extra_attr_mapping,
+        ]
+        attrs = list({a for a in candidates if a is not None})
+
+        limit = hints.limit if hints else None
+
+        with self.get_connection() as conn:
+            try:
+                if conn.page_size and limit:
+                    res = conn._paged_search_s(
+                        self.tree_dn,
+                        self.LDAP_SCOPE,
+                        query,
+                        attrs,
+                        sizelimit=limit['limit'],
+                    )
+                elif conn.page_size:
+                    res = conn._paged_search_s(
+                        self.tree_dn, self.LDAP_SCOPE, query, attrs
+                    )
+                else:
                     res = conn.search_s(
                         self.tree_dn, self.LDAP_SCOPE, query, attrs
                     )
-                except ldap.NO_SUCH_OBJECT:
-                    return []
+            except ldap.NO_SUCH_OBJECT:
+                return []
         # TODO(prashkre): add functional testing for missing name attribute
         # on ldap entities.
         # NOTE(prashkre): Filter ldap search result to keep keystone away from

--- a/keystone/tests/unit/fakeldap.py
+++ b/keystone/tests/unit/fakeldap.py
@@ -626,21 +626,54 @@ class FakeLdap(common.LDAPHandler):
         # that's why we use only the first 5.
         results = self.search_s(*params[:5])
 
-        # extract limit from serverctrl
         serverctrls = params[5]
-        ctrl = serverctrls[0]
+        ctrl = serverctrls[0] if serverctrls else None
 
-        if ctrl.size:
-            rdata = results[: ctrl.size]
+        if ctrl and hasattr(ctrl, 'size') and ctrl.size:
+            cookie = self._get_paging_cookie(ctrl)
+            start_index = int(cookie) if cookie and cookie.isdigit() else 0
+            end_index = start_index + ctrl.size
+
+            rdata = results[start_index:end_index]
+
+            next_cookie = str(end_index) if end_index < len(results) else ''
+
+            response_ctrl = self._create_paging_control(ctrl.size, next_cookie)
+            serverctrls = [response_ctrl]
         else:
             rdata = results
+            serverctrls = []
 
-        # real result3 returns various service info -- rtype, rmsgid,
-        # serverctrls. Now this info is not used, so all this info is None
-        rtype = None
-        rmsgid = None
-        serverctrls = None
-        return (rtype, rdata, rmsgid, serverctrls)
+        # Return result tuple (rtype, rdata, rmsgid, serverctrls)
+        return (None, rdata, None, serverctrls)
+
+    def _get_paging_cookie(self, ctrl):
+        """Extract the paging cookie from a control.
+
+        Supports both old (python-ldap < 2.4) and new (>= 2.4) APIs.
+        """
+        if hasattr(ctrl, 'cookie'):
+            # New API (python-ldap >= 2.4)
+            return ctrl.cookie
+        elif hasattr(ctrl, 'controlValue'):
+            # Old API (python-ldap < 2.4)
+            return ctrl.controlValue[1]
+        return ''
+
+    def _create_paging_control(self, page_size, cookie):
+        """Create a paging response control with the given cookie."""
+        if hasattr(ldap.controls, 'SimplePagedResultsControl'):
+            # New API (python-ldap >= 2.4)
+            return ldap.controls.SimplePagedResultsControl(
+                criticality=False, size=page_size, cookie=cookie
+            )
+        else:
+            # Old API (python-ldap < 2.4)
+            return ldap.controls.SimplePagedResultsControl(
+                controlType=ldap.LDAP_CONTROL_PAGE_OID,
+                criticality=False,
+                controlValue=(page_size, cookie),
+            )
 
 
 class FakeLdapPool(FakeLdap):

--- a/keystone/tests/unit/identity/backends/test_ldap_common.py
+++ b/keystone/tests/unit/identity/backends/test_ldap_common.py
@@ -460,6 +460,43 @@ class LDAPPagedResultsTest(unit.TestCase):
         attrlist = sorted([attr for attr in args[3] if attr])
         self.assertEqual(['mail', 'userPassword'], attrlist)
 
+    def test_list_users_returns_all_pages(self):
+        """Verify that list_users returns entries beyond a single page.
+
+        When the LDAP server enforces a page size limit (e.g. AD MaxPageSize),
+        _paged_search_s must loop through pages using the cookie and accumulate
+        all results.  This test uses page_size=2 with more users than that to
+        ensure all pages are fetched.
+        """
+        # Create extra users so total > page_size
+        extra_users = []
+        for _ in range(5):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            user = PROVIDERS.identity_api.create_user(user)
+            extra_users.append(user)
+
+        # page_size=2 forces multiple LDAP pages to be fetched
+        self.config_fixture.config(group='ldap', page_size=2)
+
+        with mock.patch.object(
+            common_ldap.KeystoneLDAPHandler,
+            '_paged_search_s',
+            wraps=common_ldap.KeystoneLDAPHandler._paged_search_s,
+        ) as mock_paged:
+            users = PROVIDERS.identity_api.list_users()
+            self.assertTrue(
+                mock_paged.called,
+                '_paged_search_s was not called; pagination may be bypassed',
+            )
+
+        # All default fixture users plus the extra ones must be present
+        expected_count = len(default_fixtures.USERS) + len(extra_users)
+        self.assertEqual(expected_count, len(users))
+
+        extra_ids = {u['id'] for u in extra_users}
+        returned_ids = {u['id'] for u in users}
+        self.assertTrue(extra_ids.issubset(returned_ids))
+
 
 class CommonLdapTestCase(unit.BaseTestCase):
     """These test cases call functions in keystone.common.ldap."""


### PR DESCRIPTION
Cherry-pick: [Fix LDAP pagination to return all users beyond page_size](https://review.opendev.org/c/openstack/keystone/+/982913)

Upstream: https://review.opendev.org/c/openstack/keystone/+/982913

When listing LDAP users, Keystone only returned the first page of results due to a broken _ldap_get_limited code path. This removes it and routes all queries through _paged_search_s which properly iterates through all pages.