### PR TITLE
fix(ldap): sync test_ldap_common with upstream reviewed version

### DIFF
--- a/keystone/identity/backends/ldap/common.py
+++ b/keystone/identity/backends/ldap/common.py
@@ -1143,6 +1143,7 @@ class KeystoneLDAPHandler(LDAPHandler):
         filterstr='(objectClass=*)',
         attrlist=None,
         attrsonly=0,
+        sizelimit=0,
     ):
         # NOTE(morganfainberg): Remove "None" singletons from this list, which
         # allows us to set mapped attributes to "None" as defaults in config.
@@ -1160,13 +1161,15 @@ class KeystoneLDAPHandler(LDAPHandler):
         )
         if self.page_size:
             ldap_result = self._paged_search_s(
-                base, scope, filterstr, attrlist
+                base, scope, filterstr, attrlist, sizelimit=sizelimit
             )
         else:
             try:
                 ldap_result = self.conn.search_s(
                     base, scope, filterstr, attrlist, attrsonly
                 )
+                if sizelimit:
+                    ldap_result = ldap_result[:sizelimit]
             except ldap.SIZELIMIT_EXCEEDED:
                 raise exception.LDAPSizeLimitExceeded()
 
@@ -1217,8 +1220,6 @@ class KeystoneLDAPHandler(LDAPHandler):
     def _paged_search_s(
         self, base, scope, filterstr, attrlist=None, sizelimit=0
     ):
-        if attrlist is not None:
-            attrlist = [attr for attr in attrlist if attr is not None]
         res = []
         use_old_paging_api = False
         # The API for the simple paged results control changed between
@@ -1245,16 +1246,15 @@ class KeystoneLDAPHandler(LDAPHandler):
         while True:
             # Request to the ldap server a page with 'page_size' entries
             rtype, rdata, rmsgid, serverctrls = self.conn.result3(message)
-            res.extend(convert_ldap_result(rdata))
+            res.extend(rdata or [])
 
-            # Handle case where serverctrls is None (e.g., in fake LDAP)
             pctrls = [
                 c
                 for c in (serverctrls or [])
                 if c.controlType == page_ctrl_oid
             ]
 
-            # Check if we've collected enough results
+            # Stop once we have accumulated enough results.
             if sizelimit and len(res) >= sizelimit:
                 res = res[:sizelimit]
                 break
@@ -1827,33 +1827,24 @@ class BaseLdap:
             self.object_class,
             self.id_attr,
         )
-        candidates = [
-            self.id_attr,
-            *self.attribute_mapping.values(),
-            *self.extra_attr_mapping,
-        ]
-        attrs = list({a for a in candidates if a is not None})
-
-        limit = hints.limit if hints else None
+        attrs = list(
+            set(
+                [self.id_attr]
+                + list(self.attribute_mapping.values())
+                + list(self.extra_attr_mapping.keys())
+            )
+        )
+        sizelimit = hints.limit['limit'] if hints and hints.limit else 0
 
         with self.get_connection() as conn:
             try:
-                if conn.page_size and limit:
-                    res = conn._paged_search_s(
-                        self.tree_dn,
-                        self.LDAP_SCOPE,
-                        query,
-                        attrs,
-                        sizelimit=limit['limit'],
-                    )
-                elif conn.page_size:
-                    res = conn._paged_search_s(
-                        self.tree_dn, self.LDAP_SCOPE, query, attrs
-                    )
-                else:
-                    res = conn.search_s(
-                        self.tree_dn, self.LDAP_SCOPE, query, attrs
-                    )
+                res = conn.search_s(
+                    self.tree_dn,
+                    self.LDAP_SCOPE,
+                    query,
+                    attrs,
+                    sizelimit=sizelimit,
+                )
             except ldap.NO_SUCH_OBJECT:
                 return []
         # TODO(prashkre): add functional testing for missing name attribute

--- a/keystone/tests/unit/fakeldap.py
+++ b/keystone/tests/unit/fakeldap.py
@@ -648,32 +648,12 @@ class FakeLdap(common.LDAPHandler):
         return (None, rdata, None, serverctrls)
 
     def _get_paging_cookie(self, ctrl):
-        """Extract the paging cookie from a control.
-
-        Supports both old (python-ldap < 2.4) and new (>= 2.4) APIs.
-        """
-        if hasattr(ctrl, 'cookie'):
-            # New API (python-ldap >= 2.4)
-            return ctrl.cookie
-        elif hasattr(ctrl, 'controlValue'):
-            # Old API (python-ldap < 2.4)
-            return ctrl.controlValue[1]
-        return ''
+        return ctrl.cookie
 
     def _create_paging_control(self, page_size, cookie):
-        """Create a paging response control with the given cookie."""
-        if hasattr(ldap.controls, 'SimplePagedResultsControl'):
-            # New API (python-ldap >= 2.4)
-            return ldap.controls.SimplePagedResultsControl(
-                criticality=False, size=page_size, cookie=cookie
-            )
-        else:
-            # Old API (python-ldap < 2.4)
-            return ldap.controls.SimplePagedResultsControl(
-                controlType=ldap.LDAP_CONTROL_PAGE_OID,
-                criticality=False,
-                controlValue=(page_size, cookie),
-            )
+        return ldap.controls.SimplePagedResultsControl(
+            criticality=False, size=page_size, cookie=cookie
+        )
 
 
 class FakeLdapPool(FakeLdap):

--- a/keystone/tests/unit/identity/backends/test_ldap_common.py
+++ b/keystone/tests/unit/identity/backends/test_ldap_common.py
@@ -460,6 +460,26 @@ class LDAPPagedResultsTest(unit.TestCase):
         attrlist = sorted([attr for attr in args[3] if attr])
         self.assertEqual(['mail', 'userPassword'], attrlist)
 
+    @mock.patch.object(fakeldap.FakeLdap, 'search_ext')
+    @mock.patch.object(fakeldap.FakeLdap, 'result3')
+    def test_paged_search_handles_none_from_result3(
+        self, mock_result3, mock_search_ext
+    ):
+        """Verify _paged_search_s tolerates None rdata/serverctrls from result3.
+
+        The python-ldap result3 docs do not exclude None as a possible value
+        for rdata or serverctrls.  The implementation must not crash on either.
+        """
+        mock_result3.return_value = ('', None, 1, None)
+
+        self.config_fixture.config(group='ldap', page_size=1)
+
+        conn = PROVIDERS.identity_api.user.get_connection()
+        result = conn._paged_search_s(
+            'dc=example,dc=test', ldap.SCOPE_SUBTREE, 'objectclass=*'
+        )
+        self.assertEqual([], result)
+
     def test_list_users_returns_all_pages(self):
         """Verify that list_users returns entries beyond a single page.
 
@@ -475,17 +495,19 @@ class LDAPPagedResultsTest(unit.TestCase):
             user = PROVIDERS.identity_api.create_user(user)
             extra_users.append(user)
 
-        # page_size=2 forces multiple LDAP pages to be fetched
+        # page_size=2 forces multiple LDAP pages to be fetched.
         self.config_fixture.config(group='ldap', page_size=2)
+        PROVIDERS.identity_api.user.page_size = 2
 
         with mock.patch.object(
             common_ldap.KeystoneLDAPHandler,
             '_paged_search_s',
-            wraps=common_ldap.KeystoneLDAPHandler._paged_search_s,
-        ) as mock_paged:
+            autospec=True,
+            side_effect=common_ldap.KeystoneLDAPHandler._paged_search_s,
+        ) as spy:
             users = PROVIDERS.identity_api.list_users()
             self.assertTrue(
-                mock_paged.called,
+                spy.called,
                 '_paged_search_s was not called; pagination may be bypassed',
             )
 
@@ -496,6 +518,62 @@ class LDAPPagedResultsTest(unit.TestCase):
         extra_ids = {u['id'] for u in extra_users}
         returned_ids = {u['id'] for u in users}
         self.assertTrue(extra_ids.issubset(returned_ids))
+
+    def test_search_s_sizelimit_stops_pagination(self):
+        """Verify search_s stops fetching pages once sizelimit is reached.
+
+        When page_size is set and sizelimit is passed, _paged_search_s must
+        stop accumulating results after sizelimit entries even if the server
+        has more pages available.
+        """
+        for _ in range(5):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            PROVIDERS.identity_api.create_user(user)
+
+        sizelimit = 3
+        self.config_fixture.config(group='ldap', page_size=2)
+        PROVIDERS.identity_api.user.page_size = 2
+
+        user_api = PROVIDERS.identity_api.user
+        query = (
+            f'(&(objectClass={user_api.object_class})({user_api.id_attr}=*))'
+        )
+        conn = PROVIDERS.identity_api.user.get_connection()
+        res = conn.search_s(
+            user_api.tree_dn, user_api.LDAP_SCOPE, query, sizelimit=sizelimit
+        )
+        self.assertEqual(sizelimit, len(res))
+
+    def test_list_users_with_page_size_and_limit(self):
+        """Verify list_users truncates correctly when paging and a limit are set.
+
+        This covers the path where both conn.page_size and hints.limit are set,
+        e.g. page_size=1000 and list_limit=1500 against AD with MaxPageSize=1000.
+        """
+        for _ in range(10):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            PROVIDERS.identity_api.create_user(user)
+
+        list_limit = len(default_fixtures.USERS) + 2
+        self.config_fixture.config(group='ldap', page_size=2)
+        PROVIDERS.identity_api.user.page_size = 2
+
+        hints = driver_hints.Hints()
+        hints.set_limit(list_limit)
+
+        with mock.patch.object(
+            common_ldap.KeystoneLDAPHandler,
+            '_paged_search_s',
+            autospec=True,
+            side_effect=common_ldap.KeystoneLDAPHandler._paged_search_s,
+        ) as spy:
+            users = PROVIDERS.identity_api.list_users(hints=hints)
+            self.assertTrue(
+                spy.called,
+                '_paged_search_s was not called; pagination may be bypassed',
+            )
+
+        self.assertLessEqual(len(users), list_limit)
 
 
 class CommonLdapTestCase(unit.BaseTestCase):
@@ -731,3 +809,25 @@ class LDAPSizeLimitTest(unit.TestCase):
             'dc=example,dc=test',
             ldap.SCOPE_SUBTREE,
         )
+
+    def test_search_s_sizelimit_enforced_without_paging(self):
+        """Verify search_s trims results to sizelimit when page_size is unset.
+
+        When page_size is 0 (disabled), sizelimit must still be honoured by
+        slicing the raw result set before returning it.
+        """
+        for _ in range(5):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            PROVIDERS.identity_api.create_user(user)
+
+        sizelimit = 2
+        # page_size defaults to 0 via backend_ldap.conf - no paging path taken
+        user_api = PROVIDERS.identity_api.user
+        query = (
+            f'(&(objectClass={user_api.object_class})({user_api.id_attr}=*))'
+        )
+        conn = user_api.get_connection()
+        res = conn.search_s(
+            user_api.tree_dn, user_api.LDAP_SCOPE, query, sizelimit=sizelimit
+        )
+        self.assertEqual(sizelimit, len(res))


### PR DESCRIPTION
## Summary

- Cherry-pick of upstream commit `18e6fd7d6` (the Gerrit-reviewed version of our original `fix/ldap-pagination` patch)

## Changes

- Add `PROVIDERS.identity_api.user.page_size = 2` to fix `test_list_users_returns_all_pages` (root cause of CI failure: `page_size` set via config fixture was not picked up by already-initialized backend)