### PR TITLE
Fix LDAP marker pagination returning wrong page

### DIFF
--- a/keystone/identity/backends/ldap/common.py
+++ b/keystone/identity/backends/ldap/common.py
@@ -1835,6 +1835,10 @@ class BaseLdap:
             )
         )
         sizelimit = hints.limit['limit'] if hints and hints.limit else 0
+        # Disable server-side limit when paginating — we need all results to
+        # apply the marker client-side.
+        if hints and hints.marker:
+            sizelimit = 0
 
         with self.get_connection() as conn:
             try:
@@ -1854,7 +1858,19 @@ class BaseLdap:
         # a condition '(!(!(self.attribute_mapping.get('name')=*))' to ldap
         # search query but the repsonse time of the query is pretty slow when
         # compared to explicit filtering by 'name' through ldap result.
-        return self._filter_ldap_result_by_attr(res, 'name')
+        res = self._filter_ldap_result_by_attr(res, 'name')
+
+        if hints and hints.marker:
+            # LDAP has no keyset pagination; apply the marker client-side.
+            id_attr = self.id_attr.lower()
+            for i, obj in enumerate(res):
+                lower_attrs = {k.lower(): v for k, v in obj[1].items()}
+                id_vals = lower_attrs.get(id_attr)
+                if id_vals and id_vals[0] == hints.marker:
+                    res = res[i + 1:]
+                    break
+
+        return res
 
     def _ldap_get_list(
         self,

--- a/keystone/identity/core.py
+++ b/keystone/identity/core.py
@@ -1290,6 +1290,13 @@ class Manager(manager.Manager):
             # driver selection, so remove any such filter.
             self._mark_domain_id_filter_satisfied(hints)
         hints = self._translate_expired_password_hints(hints)
+        # LDAP markers are public (hashed) IDs; resolve to local IDs for the driver.
+        if hints.marker and not driver.generates_uuids():
+            local_id_ref = PROVIDERS.id_mapping_api.get_id_mapping(
+                hints.marker
+            )
+            if local_id_ref:
+                hints.set_marker(local_id_ref['local_id'])
         ref_list = self._handle_shadow_and_local_users(driver, hints)
         return self._set_domain_id_and_mapping(
             ref_list, domain_scope, driver, mapping.EntityType.USER

--- a/keystone/tests/unit/identity/backends/test_ldap_common.py
+++ b/keystone/tests/unit/identity/backends/test_ldap_common.py
@@ -575,6 +575,91 @@ class LDAPPagedResultsTest(unit.TestCase):
 
         self.assertLessEqual(len(users), list_limit)
 
+    def test_list_users_marker_pagination_returns_next_page(self):
+        """Verify that a marker on an LDAP-backed domain returns the next page.
+
+        The LDAP backend has no native keyset pagination, so it must apply the
+        marker client-side after fetching all results.  This test ensures that
+        passing a marker returns users strictly after the marker entry and that
+        the result is consistent (same entries regardless of which worker/
+        process handles the request).
+        """
+        # Create enough users so that two full pages exist.
+        total = len(default_fixtures.USERS) + 6
+        for _ in range(6):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            PROVIDERS.identity_api.create_user(user)
+
+        page_size = total // 2
+        hints_p1 = driver_hints.Hints()
+        hints_p1.set_limit(page_size)
+        page1 = PROVIDERS.identity_api.list_users(hints=hints_p1)
+        self.assertEqual(page_size, len(page1))
+
+        # Use the last entry of page 1 as the marker for page 2.
+        marker_id = page1[-1]['id']
+        hints_p2 = driver_hints.Hints()
+        hints_p2.set_limit(page_size)
+        hints_p2.set_marker(marker_id)
+        page2 = PROVIDERS.identity_api.list_users(hints=hints_p2)
+
+        # Page 2 must not overlap with page 1.
+        page1_ids = {u['id'] for u in page1}
+        page2_ids = {u['id'] for u in page2}
+        self.assertFalse(
+            page1_ids & page2_ids,
+            'Pages overlap: marker pagination returned duplicate entries',
+        )
+        self.assertTrue(page2_ids, 'Page 2 is empty — marker was not applied')
+
+    def test_list_users_marker_not_in_sizelimit(self):
+        """Verify that sizelimit is not applied when a marker is present.
+
+        Without this, the server-side sizelimit would cap the LDAP query before
+        the marker entry is reached, causing the marker to never be found and
+        the response to restart from the beginning.
+        """
+        for _ in range(6):
+            user = unit.new_user_ref(domain_id=CONF.identity.default_domain_id)
+            PROVIDERS.identity_api.create_user(user)
+
+        total = len(PROVIDERS.identity_api.list_users())
+        page_size = total // 2
+
+        hints_p1 = driver_hints.Hints()
+        hints_p1.set_limit(page_size)
+        page1 = PROVIDERS.identity_api.list_users(hints=hints_p1)
+
+        marker_id = page1[-1]['id']
+        hints_p2 = driver_hints.Hints()
+        hints_p2.set_limit(page_size)
+        hints_p2.set_marker(marker_id)
+
+        # Spy on search_s to capture the sizelimit argument.
+        user_api = PROVIDERS.identity_api.user
+        original_search_s = user_api.get_connection().__class__.search_s
+        sizelimits_seen = []
+
+        def capturing_search_s(self_conn, base, scope, filterstr,
+                                attrlist=None, attrsonly=0, sizelimit=0):
+            sizelimits_seen.append(sizelimit)
+            return original_search_s(
+                self_conn, base, scope, filterstr, attrlist, attrsonly,
+                sizelimit,
+            )
+
+        with mock.patch.object(
+            user_api.get_connection().__class__,
+            'search_s',
+            capturing_search_s,
+        ):
+            PROVIDERS.identity_api.list_users(hints=hints_p2)
+
+        self.assertTrue(
+            all(sl == 0 for sl in sizelimits_seen),
+            f'Expected sizelimit=0 when marker is set, got {sizelimits_seen}',
+        )
+
 
 class CommonLdapTestCase(unit.BaseTestCase):
     """These test cases call functions in keystone.common.ldap."""


### PR DESCRIPTION
## Problem

After the LDAP pagination fix (PR #54), following a `next` page link on an LDAP-backed domain always returns the first page again. With multiple pods behind a load balancer, this manifests as alternating between two copies of page 1.

Root cause: the LDAP backend never reads `hints.marker`. Additionally, the marker in the URL is a public (hashed) ID from the `id_mapping` table, while LDAP stores raw attribute values — so even if the backend tried to match it, the comparison would never succeed.

## Fix

- **`identity/core.py`**: before passing hints to the driver, resolve the public marker ID back to the local LDAP attribute value via `id_mapping_api`. Only done for drivers where `generates_uuids()` is False (i.e. LDAP).
- **`common.py`**: apply the marker client-side after fetching results. Also disable the server-side `sizelimit` when a marker is present — otherwise the LDAP query is capped before the marker entry is reached.

## Testing

Tested locally with 2000 users in OpenLDAP, `list_limit=1500`, `page_size=100` (simulating AD MaxPageSize). Page 1 returns users 0–1499, page 2 returns 1500–1999, consistent across both gunicorn workers.

Unit tests added for marker pagination and sizelimit behavior.